### PR TITLE
Add popups when errors occur, fix #38

### DIFF
--- a/apps/browser/css/layout.css
+++ b/apps/browser/css/layout.css
@@ -42,6 +42,11 @@ tab-iframe, box, hbox, vbox, spacer {
   white-space: pre;
 }
 
+tab-iframe {
+  overflow: hidden;
+  position: relative;
+}
+
 hbox {
   flex-flow: row;
 }

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -1,0 +1,52 @@
+.popup {
+  position:fixed;
+  top:30vh;
+  left:30vw;
+  background:#F8F8F8;
+  color:#777;
+  padding:2em;
+  box-shadow:0px 27px 24px 0px rgba(0, 0, 0, 0.2), 0px 40px 77px 0px rgba(0, 0, 0, 0.22), 0px -5px 24px 0px rgba(0, 0, 0, 0.2);
+  min-width: 200px;
+  min-height: 40vh;
+  max-height: 70vh;
+  overflow: auto;
+  width:40vw;
+  height:auto;
+  transition:0.07s;
+  -moz-user-select:none;
+}
+.popup > h1 {
+  font-size:275%;
+  font-weight: 300;
+  margin:0.3em;
+  padding-bottom:0.25em;
+  box-sizing: border-box;
+  border-bottom:1px #999 solid;
+  color:#444;
+}
+.popup > .content {
+  padding:0.5em;
+  font-size:150%;
+  font-weight: 300;
+  line-height: 130%;
+}
+.button {
+  position: absolute;
+  font-size:17px;
+  font-weight: 300;
+  bottom:20px;
+  right:25px;
+  height:40px;
+  width:160px;
+  padding:0.3em;
+  padding-top:11px;
+  box-sizing: border-box;
+background:#0095DD;
+  color:#FBFBFB;
+  border-radius: 2px;
+  text-align: center;
+  cursor:pointer;
+}
+.button:hover {
+  background: #0086C7;
+}

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -1,62 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .popup {
   display: flex;
   flex-wrap: wrap;
-  background:#F8F8F8;
-  color:#777;
-  box-shadow:0px 27px 24px 0px rgba(0, 0, 0, 0.2), 0px 40px 77px 0px rgba(0, 0, 0, 0.22), 0px -5px 24px 0px rgba(0, 0, 0, 0.2);
-  -moz-user-select:none;
-  padding:2em;
-  height:auto;
-  width:auto;
+  background: #F8F8F8;
+  color: #777;
+  box-shadow: 0px 27px 24px 0px rgba(0, 0, 0, 0.2), 0px 40px 77px 0px rgba(0, 0, 0, 0.22), 0px -5px 24px 0px rgba(0, 0, 0, 0.2);
+  -moz-user-select: none;
+  padding: 2em;
+  height: auto;
+  width: auto;
   max-width: 500px;
   max-height: 275px;
   z-index: 999999;
-  overflow:auto;
-  margin:auto;
-  position:absolute;
-  top:0;
-  bottom:0;
-  left:0;
-  right:0;
+  overflow: auto;
+  margin: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   white-space: normal;
 }
 
 tab-iframe > .popup {
   max-width: none;
   max-height: none;
-  padding:9em;
+  padding: 9em;
 }
 
 .popup > h1 {
-  font-size:275%;
+  font-size: 275%;
   font-weight: 300;
-  margin:0.3em;
-  height:50px;
+  margin: 0.3em;
+  height: 50px;
   white-space: nowrap;
-  padding-bottom:0.25em;
+  padding-bottom: 0.25em;
   box-sizing: border-box;
-  border-bottom:1px #999 solid;
-  color:#444;
+  border-bottom: 1px #999 solid;
+  color: #444;
   min-width: 100%;
   overflow: hidden;
 }
 .popup > .content {
-  padding:0.5em;
-  font-size:150%;
+  padding: 0.5em;
+  font-size: 150%;
   font-weight: 300;
   line-height: 140%;
 }
 .popup > button {
-  font-size:17px;
+  font-size: 17px;
   font-weight: 300;
-  height:40px;
-  width:160px;
+  height: 40px;
+  width: 160px;
   box-sizing: border-box;
-background:#0095DD;
-  color:#FBFBFB;
+background: #0095DD;
+  color: #FBFBFB;
   border-radius: 2px;
   text-align: center;
-  cursor:pointer;
+  cursor: pointer;
   min-width: 100%;
 }
 .popup > button:hover {

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -13,13 +13,19 @@
   z-index: 999999;
   overflow:auto;
   margin:auto;
-  position:fixed;
+  position:absolute;
   top:0;
   bottom:0;
   left:0;
   right:0;
   white-space: normal;
 }
+
+tab-iframe > .popup {
+  max-width: none;
+  max-height: none;
+}
+
 .popup > h1 {
   font-size:275%;
   font-weight: 300;

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -1,5 +1,5 @@
 .popup {
-  display: none; /* changed to flex in popup.js */
+  display: flex;
   flex-wrap: wrap;
   background:#F8F8F8;
   color:#777;
@@ -18,6 +18,7 @@
   bottom:0;
   left:0;
   right:0;
+  white-space: normal;
 }
 .popup > h1 {
   font-size:275%;

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -1,5 +1,5 @@
 .popup {
-  display: flex;
+  display: none; /* changed to flex in popup.js */
   flex-wrap: wrap;
   background:#F8F8F8;
   color:#777;
@@ -8,8 +8,8 @@
   padding:2em;
   height:auto;
   width:auto;
-  max-width: 600px;
-  max-height: 350px;
+  max-width: 500px;
+  max-height: 275px;
   z-index: 999999;
   overflow:auto;
   margin:auto;
@@ -28,6 +28,7 @@
   box-sizing: border-box;
   border-bottom:1px #999 solid;
   color:#444;
+  min-width: 100%;
 }
 .popup > .content {
   padding:0.5em;
@@ -46,6 +47,7 @@ background:#0095DD;
   border-radius: 2px;
   text-align: center;
   cursor:pointer;
+  min-width: 100%;
 }
 .popup > button:hover {
   background: #0086C7;

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -1,24 +1,29 @@
 .popup {
-  position:fixed;
-  top:30vh;
-  left:30vw;
+  display: flex;
+  flex-wrap: wrap;
   background:#F8F8F8;
   color:#777;
-  padding:2em;
   box-shadow:0px 27px 24px 0px rgba(0, 0, 0, 0.2), 0px 40px 77px 0px rgba(0, 0, 0, 0.22), 0px -5px 24px 0px rgba(0, 0, 0, 0.2);
-  min-width: 200px;
-  min-height: 40vh;
-  max-height: 70vh;
-  overflow: auto;
-  width:40vw;
-  height:auto;
-  transition:0.07s;
   -moz-user-select:none;
+  padding:2em;
+  height:auto;
+  width:auto;
+  max-width: 600px;
+  max-height: 350px;
+  z-index: 999999;
+  overflow:auto;
+  margin:auto;
+  position:fixed;
+  top:0;
+  bottom:0;
+  left:0;
+  right:0;
 }
 .popup > h1 {
   font-size:275%;
   font-weight: 300;
   margin:0.3em;
+  height:50px;
   padding-bottom:0.25em;
   box-sizing: border-box;
   border-bottom:1px #999 solid;
@@ -30,16 +35,11 @@
   font-weight: 300;
   line-height: 130%;
 }
-.button {
-  position: absolute;
+.popup > button {
   font-size:17px;
   font-weight: 300;
-  bottom:20px;
-  right:25px;
   height:40px;
   width:160px;
-  padding:0.3em;
-  padding-top:11px;
   box-sizing: border-box;
 background:#0095DD;
   color:#FBFBFB;
@@ -47,6 +47,6 @@ background:#0095DD;
   text-align: center;
   cursor:pointer;
 }
-.button:hover {
+.popup > button:hover {
   background: #0086C7;
 }

--- a/apps/browser/css/popup.css
+++ b/apps/browser/css/popup.css
@@ -24,6 +24,7 @@
 tab-iframe > .popup {
   max-width: none;
   max-height: none;
+  padding:9em;
 }
 
 .popup > h1 {
@@ -31,17 +32,19 @@ tab-iframe > .popup {
   font-weight: 300;
   margin:0.3em;
   height:50px;
+  white-space: nowrap;
   padding-bottom:0.25em;
   box-sizing: border-box;
   border-bottom:1px #999 solid;
   color:#444;
   min-width: 100%;
+  overflow: hidden;
 }
 .popup > .content {
   padding:0.5em;
   font-size:150%;
   font-weight: 300;
-  line-height: 130%;
+  line-height: 140%;
 }
 .popup > button {
   font-size:17px;

--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -15,7 +15,6 @@
     <title>firefox</title>
     <link rel='stylesheet' href='css/layout.css'>
     <link rel='stylesheet' title='default' href='css/theme.css'>
-    <link rel='stylesheet' title='default' href='css/popup.css'>
 
     <!-- Alternate themes -->
     <link rel='stylesheet alternate' title='dark' href='css/dark/dark.css'>

--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -26,9 +26,8 @@
     <script src='js/sanitycheck.js'></script>
   </head>
 
-  <body>             
+  <body>
 
-    
     <vbox id='outervbox' flex='1'> <!-- This is not XUL. It's html. -->
       <hbox id='outerhbox' flex='1'>
         <box class='iframes' flex='1' align='stretch'></box>

--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -15,6 +15,7 @@
     <title>firefox</title>
     <link rel='stylesheet' href='css/layout.css'>
     <link rel='stylesheet' title='default' href='css/theme.css'>
+    <link rel='stylesheet' title='default' href='css/popup.css'>
 
     <!-- Alternate themes -->
     <link rel='stylesheet alternate' title='dark' href='css/dark/dark.css'>
@@ -27,7 +28,11 @@
   </head>
 
   <body>
+    <div class="popup"><h1 flex="1">Lorem Ipsum</h1><div class="content" flex="1">
 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum maximus pharetra urna, pharetra aliquet lacus condimentum interdum. Integer tempus enim eros, ac pharetra lectus consectetur at. Morbi vehicula mauris augue, vitae interdum magna porttitor at. Aliquam erat volutpat. Proin nisl nunc, congue ac urna et, pulvinar fringilla eros. Sed fermentum elit sed interdum placerat. Vivamus cursus fermentum tristique. Aliquam erat volutpat. </div><button class="close" flex="1">Okay</button></div>                
+
+    
     <vbox id='outervbox' flex='1'> <!-- This is not XUL. It's html. -->
       <hbox id='outerhbox' flex='1'>
         <box class='iframes' flex='1' align='stretch'></box>

--- a/apps/browser/index.html
+++ b/apps/browser/index.html
@@ -27,10 +27,7 @@
     <script src='js/sanitycheck.js'></script>
   </head>
 
-  <body>
-    <div class="popup"><h1 flex="1">Lorem Ipsum</h1><div class="content" flex="1">
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum maximus pharetra urna, pharetra aliquet lacus condimentum interdum. Integer tempus enim eros, ac pharetra lectus consectetur at. Morbi vehicula mauris augue, vitae interdum magna porttitor at. Aliquam erat volutpat. Proin nisl nunc, congue ac urna et, pulvinar fringilla eros. Sed fermentum elit sed interdum placerat. Vivamus cursus fermentum tristique. Aliquam erat volutpat. </div><button class="close" flex="1">Okay</button></div>                
+  <body>             
 
     
     <vbox id='outervbox' flex='1'> <!-- This is not XUL. It's html. -->

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -14,7 +14,13 @@ define([],
 
   'use strict';
   
-    let html = `<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>`;
+  let link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'css/popup.css';
+  let defaultStyleSheet = document.querySelector('link[title=default]');
+  document.head.insertBefore(link, defaultStyleSheet.nextSibling);
+  
+  let html = `<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>`;
   let body = document.body;
   let placeholder = document.createElement('div');
   let outervbox = document.querySelector("#outervbox");

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -20,36 +20,38 @@ define([],
   let defaultStyleSheet = document.querySelector('link[title=default]');
   document.head.insertBefore(link, defaultStyleSheet.nextSibling);
 
-  let html = `<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>`;
-  let body = document.body;
-  let placeholder = document.createElement('div');
-  let outervbox = document.querySelector('#outervbox');
-  body.insertBefore(placeholder, outervbox);
-  placeholder.outerHTML = html;
-
-  let el = document.querySelector('.popup');
-  let elheading = document.querySelector('.popup > h1');
-  let elcontent = document.querySelector('.popup > .content');
-  let elbutton = document.querySelector('.popup > button');
+  let html = `<div class="popup"><h1 flex="1">headerinsert</h1><div class="content" flex="1">contentinsert</div><button class="close" flex="1">btinsert</button></div>`;
 
   const Popup = {
     openPopup: function(options) {
-      elheading.innerHTML = options.title;
-      elcontent.innerHTML = options.content;
+      
+      var generatedhtml = html;
+      generatedhtml = generatedhtml.replace("headerinsert", options.title).replace("contentinsert", options.content);
+        if (options.buttontext) {
+          generatedhtml = generatedhtml.replace("btinsert", options.buttontext);
+        } else {
+          generatedhtml = generatedhtml.replace("btinsert", "Okay");
+        }
 
-      if (options.buttontext) {
-        elbutton.innerHTML = options.buttontext;
+      if(options.page) {
+        var currentTabFrame = options.tabiframetarget;
+        currentTabFrame.insertAdjacentHTML("BeforeEnd", generatedhtml);      
       } else {
-        elbutton.innerHTML = 'Okay';
+        var body = document.body;
+        var placeholder = document.createElement('div');
+        var outervbox = document.querySelector('#outervbox');
+        body.insertBefore(placeholder, outervbox);
+        placeholder.outerHTML = generatedhtml;
       }
 
-      el.style.display = 'flex';
+      document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
     },
+
   closePopup: function() {
-    el.style.display = 'none';
+    var el = document.querySelector('.popup');
+    el.parentNode.removeChild(el);
   },
   }
 
-  elbutton.addEventListener('click', Popup.closePopup);
   return Popup;
 });

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -39,7 +39,7 @@ define([],
 
       if (options.buttontext) {
         elbutton.innerHTML = options.buttontext;
-        } else {
+      } else {
         elbutton.innerHTML = 'Okay';
       }
 
@@ -47,7 +47,7 @@ define([],
     },
   closePopup: function() {
     el.style.display = 'none';
-    },
+  },
   }
 
   elbutton.addEventListener('click', Popup.closePopup);

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -34,7 +34,7 @@ define([],
       }
 
       if (options.page) {
-        var currentTabFrame = options.tabiframetarget;
+        var currentTabFrame = options.insertiontarget;
         currentTabFrame.insertAdjacentHTML('BeforeEnd', generatedhtml);
       } else {
         var body = document.body;

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -51,7 +51,7 @@ define([],
   closePopup: function() {
     var el = document.querySelector('.popup');
     el.parentNode.removeChild(el);
-      document.querySelector('.popup > button').onclick = null;
+    document.querySelector('.popup > button').onclick = null;
     document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
   },
   }

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -44,15 +44,14 @@ define([],
         placeholder.outerHTML = generatedhtml;
       }
 
-      document.querySelector('.popup > button').onclick = null;
-      document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
+      document.querySelector('.popup > button').onclick = Popup.closePopup;
     },
 
   closePopup: function() {
-    var el = document.querySelector('.popup');
-    el.parentNode.removeChild(el);
-    document.querySelector('.popup > button').onclick = null;
-    document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
+    var el = document.getElementsByClassName('popup');
+    while(el[0]) {
+      el[0].parentNode.removeChild(el[0]);
+    }  
   },
   }
 

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -13,44 +13,43 @@ define([],
        function() {
 
   'use strict';
-  
+
   let link = document.createElement('link');
   link.rel = 'stylesheet';
   link.href = 'css/popup.css';
   let defaultStyleSheet = document.querySelector('link[title=default]');
   document.head.insertBefore(link, defaultStyleSheet.nextSibling);
-  
+
   let html = `<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>`;
   let body = document.body;
   let placeholder = document.createElement('div');
-  let outervbox = document.querySelector("#outervbox");
+  let outervbox = document.querySelector('#outervbox');
   body.insertBefore(placeholder, outervbox);
   placeholder.outerHTML = html;
 
-  let el = document.querySelector(".popup");
-  let elheading = document.querySelector(".popup > h1");
-  let elcontent = document.querySelector(".popup > .content");
-  let elbutton = document.querySelector(".popup > button");
+  let el = document.querySelector('.popup');
+  let elheading = document.querySelector('.popup > h1');
+  let elcontent = document.querySelector('.popup > .content');
+  let elbutton = document.querySelector('.popup > button');
 
   const Popup = {
     openPopup: function(options) {
       elheading.innerHTML = options.title;
       elcontent.innerHTML = options.content;
-      
-      if(options.buttontext) {
-      elbutton.innerHTML = options.buttontext;
-        }
-      else {
-      elbutton.innerHTML = "Okay";
+
+      if (options.buttontext) {
+        elbutton.innerHTML = options.buttontext;
+        } else {
+        elbutton.innerHTML = 'Okay';
       }
-      
-      el.style.display = "flex";
+
+      el.style.display = 'flex';
     },
   closePopup: function() {
-    el.style.display = "none";
+    el.style.display = 'none';
     },
   }
-  
-  elbutton.addEventListener("click", Popup.closePopup);
+
+  elbutton.addEventListener('click', Popup.closePopup);
   return Popup;
 });

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -24,18 +24,18 @@ define([],
 
   const Popup = {
     openPopup: function(options) {
-      
-      var generatedhtml = html;
-      generatedhtml = generatedhtml.replace("headerinsert", options.title).replace("contentinsert", options.content);
-        if (options.buttontext) {
-          generatedhtml = generatedhtml.replace("btinsert", options.buttontext);
-        } else {
-          generatedhtml = generatedhtml.replace("btinsert", "Okay");
-        }
 
-      if(options.page) {
+      var generatedhtml = html;
+      generatedhtml = generatedhtml.replace('headerinsert', options.title).replace('contentinsert', options.content);
+      if (options.buttontext) {
+        generatedhtml = generatedhtml.replace('btinsert', options.buttontext);
+      } else {
+        generatedhtml = generatedhtml.replace('btinsert', 'Okay');
+      }
+
+      if (options.page) {
         var currentTabFrame = options.tabiframetarget;
-        currentTabFrame.insertAdjacentHTML("BeforeEnd", generatedhtml);      
+        currentTabFrame.insertAdjacentHTML('BeforeEnd', generatedhtml);
       } else {
         var body = document.body;
         var placeholder = document.createElement('div');

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -49,9 +49,9 @@ define([],
 
   closePopup: function() {
     var el = document.getElementsByClassName('popup');
-    while(el[0]) {
+    while (el[0]) {
       el[0].parentNode.removeChild(el[0]);
-    }  
+    }
   },
   }
 

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -14,9 +14,12 @@ define([],
 
   'use strict';
   
-  //really bad way of adding the popup html - needs to be changed
-  
-document.body.innerHTML = '<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>' + document.body.innerHTML; 
+    let html = `<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>`;
+  let body = document.body;
+  let placeholder = document.createElement('div');
+  let outervbox = document.querySelector("#outervbox");
+  body.insertBefore(placeholder, outervbox);
+  placeholder.outerHTML = html;
 
   let el = document.querySelector(".popup");
   let elheading = document.querySelector(".popup > h1");

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -44,12 +44,15 @@ define([],
         placeholder.outerHTML = generatedhtml;
       }
 
+      document.querySelector('.popup > button').onclick = null;
       document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
     },
 
   closePopup: function() {
     var el = document.querySelector('.popup');
     el.parentNode.removeChild(el);
+      document.querySelector('.popup > button').onclick = null;
+    document.querySelector('.popup > button').addEventListener('click', Popup.closePopup);
   },
   }
 

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -44,7 +44,10 @@ define([],
         placeholder.outerHTML = generatedhtml;
       }
 
-      document.querySelector('.popup > button').onclick = Popup.closePopup;
+      var closebuttons = document.querySelectorAll('.popup > button');
+      for (var i = 0; i < closebuttons.length; i++) {
+        closebuttons[i].onclick = Popup.closePopup;
+      }
     },
 
   closePopup: function() {

--- a/apps/browser/js/popup.js
+++ b/apps/browser/js/popup.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * popup.js
+ *
+ * This provides popups for error handling throughout browser.html
+ *
+ */
+
+define([],
+       function() {
+
+  'use strict';
+  
+  //really bad way of adding the popup html - needs to be changed
+  
+document.body.innerHTML = '<div class="popup"><h1 flex="1"></h1><div class="content" flex="1"></div><button class="close" flex="1"></button></div>' + document.body.innerHTML; 
+
+  let el = document.querySelector(".popup");
+  let elheading = document.querySelector(".popup > h1");
+  let elcontent = document.querySelector(".popup > .content");
+  let elbutton = document.querySelector(".popup > button");
+
+  const Popup = {
+    openPopup: function(options) {
+      elheading.innerHTML = options.title;
+      elcontent.innerHTML = options.content;
+      
+      if(options.buttontext) {
+      elbutton.innerHTML = options.buttontext;
+        }
+      else {
+      elbutton.innerHTML = "Okay";
+      }
+      
+      el.style.display = "flex";
+    },
+  closePopup: function() {
+    el.style.display = "none";
+    },
+  }
+  
+  elbutton.addEventListener("click", Popup.closePopup);
+  return Popup;
+});

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -237,11 +237,10 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
           Popup.openPopup({title:"Content is corrupted", content:"There is something wrong with this content that prevents it from being displayed."});
         }
         else if(e.detail.type == "remoteXUL") {
-          Popup.openPopup({title:"Remote XUl", content:"This capability is disabled and cannot be used."});
+          Popup.openPopup({title:"Remote XUL", content:"This capability is disabled and cannot be used."});
         }
         else {
           Popup.openPopup({title:"This Connection is Untrusted", content:"You have asked Firefox to connect securely to this page, but we can't confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site's identity can't be verified.", buttontext:"Get me out of here!"});
-
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -236,7 +236,7 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         } else if (e.detail.type == 'remoteXUL') {
           Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.'});
         } else {
-          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can't confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site's identity can't be verified.', buttontext:'Get me out of here!'});
+          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!'});
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -230,13 +230,13 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         if (e.detail.type == 'offline' || e.detail.type == 'dnsNotFound') {
           Popup.openPopup({title:'You are offline', content:'Please reconnect to the internet and try again.'});
         } else if (e.detail.type == 'redirectLoop') {
-          Popup.openPopup({title:'Too many redirects', content:'This page is trying to redirect you in a way that will never complete.', page: true, tabiframetarget: e.target.parentNode});
+          Popup.openPopup({title:'Too many redirects', content:'This page is trying to redirect you in a way that will never complete.', page: true, insertiontarget: e.target.parentNode});
         } else if (e.detail.type == 'corruptedContentError') {
-          Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.', page: true, tabiframetarget: e.target.parentNode});
+          Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.', page: true, insertiontarget: e.target.parentNode});
         } else if (e.detail.type == 'remoteXUL') {
-          Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, tabiframetarget: e.target.parentNode});
+          Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, insertiontarget: e.target.parentNode});
         } else {
-          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, tabiframetarget: e.target.parentNode});
+          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, insertiontarget: e.target.parentNode});
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -236,7 +236,7 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         } else if (e.detail.type == 'remoteXUL') {
           Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, insertiontarget: e.target.parentNode});
         } else if (e.detail.type == 'other') {
-          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, insertiontarget: e.target.parentNode});
+          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified. If you usually connect to this site without problems, this error could mean that someone is trying to impersonate the site, and you shouldn\'t continue.', buttontext:'Get me out of here!', page: true, insertiontarget: e.target.parentNode});
         } else {
           Popup.openPopup({title:'Error', content:'Something went wrong here. Try reloading.', page: true, insertiontarget: e.target.parentNode});
         }

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -235,7 +235,7 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
           Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.', page: true, insertiontarget: e.target.parentNode});
         } else if (e.detail.type == 'remoteXUL') {
           Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, insertiontarget: e.target.parentNode});
-        } else if (e.detail.type == 'other') {
+        } else if (e.detail.type == 'other' || e.detail.type == 'certerror') {
           Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified. If you usually connect to this site without problems, this error could mean that someone is trying to impersonate the site, and you shouldn\'t continue.', buttontext:'Get me out of here!', page: true, insertiontarget: e.target.parentNode});
         } else {
           Popup.openPopup({title:'Error', content:'Something went wrong here. Try reloading.', page: true, insertiontarget: e.target.parentNode});

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -235,8 +235,10 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
           Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.', page: true, insertiontarget: e.target.parentNode});
         } else if (e.detail.type == 'remoteXUL') {
           Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, insertiontarget: e.target.parentNode});
-        } else {
+        } else if (e.detail.type == 'other') {
           Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, insertiontarget: e.target.parentNode});
+        } else {
+          Popup.openPopup({title:'Error', content:'Something went wrong here. Try reloading.', page: true, insertiontarget: e.target.parentNode});
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -236,7 +236,7 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         } else if (e.detail.type == 'remoteXUL') {
           Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.'});
         } else {
-          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!'});
+          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, tabiframetarget: e.target.parentNode});
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -227,20 +227,16 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         this._favicon = e.detail.href;
         break;
       case 'mozbrowsererror':
-        if(e.detail.type == "offline" || e.detail.type == "dnsNotFound") {
-          Popup.openPopup({title:"You are offline", content:"Please reconnect to the internet and try again."});
-        }
-        else if(e.detail.type == "redirectLoop") {
-          Popup.openPopup({title:"Too many redirects", content:"This page is trying to redirect you in a way that will never complete."});
-        }
-        else if(e.detail.type == "corruptedContentError") {
-          Popup.openPopup({title:"Content is corrupted", content:"There is something wrong with this content that prevents it from being displayed."});
-        }
-        else if(e.detail.type == "remoteXUL") {
-          Popup.openPopup({title:"Remote XUL", content:"This capability is disabled and cannot be used."});
-        }
-        else {
-          Popup.openPopup({title:"This Connection is Untrusted", content:"You have asked Firefox to connect securely to this page, but we can't confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site's identity can't be verified.", buttontext:"Get me out of here!"});
+        if (e.detail.type == 'offline' || e.detail.type == 'dnsNotFound') {
+          Popup.openPopup({title:'You are offline', content:'Please reconnect to the internet and try again.'});
+        } else if (e.detail.type == 'redirectLoop') {
+          Popup.openPopup({title:'Too many redirects', content:'This page is trying to redirect you in a way that will never complete.'});
+        } else if (e.detail.type == 'corruptedContentError') {
+          Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.'});
+        } else if (e.detail.type == 'remoteXUL') {
+          Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.'});
+        } else {
+          Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can't confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site's identity can't be verified.', buttontext:'Get me out of here!'});
         }
         this._loading = false;
         break;

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -230,11 +230,11 @@ define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
         if (e.detail.type == 'offline' || e.detail.type == 'dnsNotFound') {
           Popup.openPopup({title:'You are offline', content:'Please reconnect to the internet and try again.'});
         } else if (e.detail.type == 'redirectLoop') {
-          Popup.openPopup({title:'Too many redirects', content:'This page is trying to redirect you in a way that will never complete.'});
+          Popup.openPopup({title:'Too many redirects', content:'This page is trying to redirect you in a way that will never complete.', page: true, tabiframetarget: e.target.parentNode});
         } else if (e.detail.type == 'corruptedContentError') {
-          Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.'});
+          Popup.openPopup({title:'Content is corrupted', content:'There is something wrong with this content that prevents it from being displayed.', page: true, tabiframetarget: e.target.parentNode});
         } else if (e.detail.type == 'remoteXUL') {
-          Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.'});
+          Popup.openPopup({title:'Remote XUL', content:'This capability is disabled and cannot be used.', page: true, tabiframetarget: e.target.parentNode});
         } else {
           Popup.openPopup({title:'This Connection is Untrusted', content:'You have asked Firefox to connect securely to this page, but we can\'t confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site\'s identity can\'t be verified.', buttontext:'Get me out of here!', page: true, tabiframetarget: e.target.parentNode});
         }

--- a/apps/browser/js/tabiframe.js
+++ b/apps/browser/js/tabiframe.js
@@ -10,7 +10,7 @@
  *
  */
 
-define(['js/eventemitter'], function(EventEmitter) {
+define(['js/eventemitter', 'js/popup'], function(EventEmitter, Popup) {
 
   'use strict';
 
@@ -227,6 +227,22 @@ define(['js/eventemitter'], function(EventEmitter) {
         this._favicon = e.detail.href;
         break;
       case 'mozbrowsererror':
+        if(e.detail.type == "offline" || e.detail.type == "dnsNotFound") {
+          Popup.openPopup({title:"You are offline", content:"Please reconnect to the internet and try again."});
+        }
+        else if(e.detail.type == "redirectLoop") {
+          Popup.openPopup({title:"Too many redirects", content:"This page is trying to redirect you in a way that will never complete."});
+        }
+        else if(e.detail.type == "corruptedContentError") {
+          Popup.openPopup({title:"Content is corrupted", content:"There is something wrong with this content that prevents it from being displayed."});
+        }
+        else if(e.detail.type == "remoteXUL") {
+          Popup.openPopup({title:"Remote XUl", content:"This capability is disabled and cannot be used."});
+        }
+        else {
+          Popup.openPopup({title:"This Connection is Untrusted", content:"You have asked Firefox to connect securely to this page, but we can't confirm that your connection is secure. Normally, when you try to connect securely, sites will present trusted identification to prove that you are going to the right place. However, this site's identity can't be verified.", buttontext:"Get me out of here!"});
+
+        }
         this._loading = false;
         break;
       case 'mozbrowsersecuritychange':


### PR DESCRIPTION
Add popups for the following errors alerting the user as to what went wrong (fixing #38):
-no internet connection
-redirect loop
-corrupted content
-remote xul
-invalid certificate

(eventually, the other error types should have popups as well, but for right now it is just these 5)

some questions:
-what should the popup messages be? Right now most of the popups are just a basic explanation or copied from firefox, but this is probably not enough.
-should there be one global popup at the document root (like there is now) or should there be individual popups attached to the tab-iframes?
-Is the trigger on the invalid certificate too broad? Right now, it just triggers on anything with type "other", but are there other situations where this type occurs that need to be taken into account?
![screen shot 2015-01-09 at 5 02 06 pm](https://cloud.githubusercontent.com/assets/10314059/5688813/550b5b54-9821-11e4-8bf2-0243f4b95c7a.png)