### PR TITLE
temporary fix for #50

### DIFF
--- a/runtime/shell.css
+++ b/runtime/shell.css
@@ -9,7 +9,6 @@ window[os=linux] {
 
 window[os=osx] {
   -moz-appearance: dialog;
-  -moz-window-dragging: drag;
 }
 
 window[os=windows] {
@@ -29,7 +28,6 @@ window:not([draw-in-titlebar]) #titlebar {
 
 window[draw-in-titlebar=true] #titlebar {
   -moz-binding: url("chrome://global/content/bindings/general.xml#windowdragbox");
-  -moz-window-dragging: drag;
 }
 
 window[draw-in-titlebar=true][os=osx] #titlebar {
@@ -67,8 +65,16 @@ browser {
   background: transparent;
 }
 
+window[os=osx][draw-in-titlebar=true] browser {
+    margin-top:-39px;
+}
+
+window[draw-in-titlebar=true][os=windows] browser {
+  margin-top: -16px;
+}
+
 #init {
-  margin: 40px;;
+  margin: 40px;
   padding: 40px;
   font: -moz-field;
   color: black;
@@ -77,4 +83,16 @@ browser {
 
 #init input {
   width: 100%;
+}
+
+window[os=osx][draw-in-titlebar=true] #dragger {
+  height:39px;
+  width:100%;
+  -moz-window-dragging:drag;
+}
+
+window[os=windows][draw-in-titlebar=true] #dragger {
+  height:16px;
+  width:100%;
+  -moz-window-dragging:drag;
 }

--- a/runtime/shell.xul
+++ b/runtime/shell.xul
@@ -204,6 +204,7 @@
     <tooltip id="contentAreaTooltip" page="true" />
   </popupset>
 
+  <hbox id="dragger"></hbox>
   <browser id="content"
            type="content-primary"
            flex="1"


### PR DESCRIPTION
fix #50 by adding an element that handles the dragging and is the height of the titlebar and also adding a negative margin to the browser element. Long-term this will not work very well, but it should be okay until window dragging can be used in html.

I have only tested this on mac, but it should work on the other platforms as well. Windows appears from the css to be the same thing but with a different toolbar height, and Linux does not support draw in titlebar as far as I can tell.