### PR TITLE
Update manifest.webapp

### DIFF
--- a/apps/browser/manifest.webapp
+++ b/apps/browser/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Browser2",
   "description": "Firefox2",
-  "launch_path": "/index.html",
+  "launch_path": "./index.html",
   "type": "certified",
   "role": "system",
   "developer": {


### PR DESCRIPTION
Launch paths are resolved against the manifest url, so to get the correct homepage from https://mozilla.github.io/browser.html/manifest.webapp we need this change.