### PR TITLE
better progressbar

### DIFF
--- a/css/locationbar.css
+++ b/css/locationbar.css
@@ -6,18 +6,25 @@
   border-radius: 3px;
   line-height: 30px;
   background-color: rgba(0,0,0,0.07);
+  position: relative;
+  overflow: hidden;
 }
 
-.navbar.loading .locationbar {
-  background-image: linear-gradient(110deg, #82D3FD, #82D3FD 80%, transparent 80%);
-  background-size: 600px 30px;
-  background-position: -460px 0;
-  background-repeat: no-repeat;
-  animation: urlloading 2s ease-out;
-  animation-fill-mode: forwards;
+.locationbar > * {
+  z-index: 100;
 }
 
-@keyframes urlloading { to { background-position: 0 0 } }
+.progressbar {
+  z-index: 99;
+  display: block;
+  width: 500px;
+  height: 30px;
+  background-image: linear-gradient(110deg, var(--progressbar-color), var(--progressbar-color) 460px, transparent 460px);
+  background-size: 500px 30px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
 
 .urlinput,
 .pagesummary {

--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -89,7 +89,8 @@ define((require, exports, module) => {
     onAuthentificate: Event('mozbrowserusernameandpasswordrequired'),
     onCanGoBackChange: Event('mozbrowsercangobackchange'),
     onCanGoForwardChange: Event('mozbrowsercangoforwardchange'),
-    onScrollAreaChange: Event('mozbrowserscrollareachanged')
+    onScrollAreaChange: Event('mozbrowserscrollareachanged'),
+    onLoadProgressChange: Event('mozbrowserloadprogresschanged')
   });
 
   IFrame.onCanGoBackChange = node => request => {

--- a/src/browser/navigation-panel.js
+++ b/src/browser/navigation-panel.js
@@ -13,6 +13,7 @@ define((require, exports, module) => {
   const {navigateTo, showTabStrip, focus} = require('./actions');
   const {KeyBindings} = require('./keyboard');
   const url = require('./util/url');
+  const {ProgressBar} = require('./progressbar');
 
   const WindowControls = Component('WindowControls', ({theme}) =>
     DOM.div({className: 'windowctrls'}, [
@@ -48,6 +49,7 @@ define((require, exports, module) => {
       className: 'locationbar',
       onMouseEnter: event => showTabStrip(tabStripCursor)
     }, [
+      ProgressBar({key: 'progressbar', webViewerCursor, theme}),
       DOM.div({className: 'backbutton',
                style: theme.backButton,
                key: 'back',

--- a/src/browser/progressbar.js
+++ b/src/browser/progressbar.js
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Progress bar logic:
+ * The progressbar is split in 3 zones. Called A, B and C.
+ *   Zone A is slowly filled while the browser is connecting to the server.
+ *   Zone B is slowly filled while the page is being downloaded.
+ *   Zone C is filled once the page has loaded (fast).
+ * Zone A and B get filled slower and slower in a way that they are never 100% filled.
+ */
+
+define((require, exports, module) => {
+
+  'use strict';
+
+  const {Element, Field} = require('./element');
+  const Component = require('omniscient');
+
+  const ProgressBarElement = Element('div', {
+    progressBarColor: Field((node, current, past) => {
+      if (current != past) {
+        node.style.setProperty('--progressbar-color', current);
+      }
+    }),
+  });
+
+  const PI = 3.1416; // > PI
+
+  // Animation parameters:
+  const A = 0.2;              // Zone A size (a full progress is equal to '1'
+  const B = 0.3;              // Zone B size
+  const APivot = 200;         // When to reach ~80% of zone A
+  const BPivot = 500;         // When to reach ~80% of zone B
+  const CSpeed = 0.002;       // Speed to fill zone C (how fast we reach '1')
+  const StartFading = 0.8;    // When does opacity starts decreasing to 0
+
+  // Inverse tangent function: [0 - inf] -> [0 - PI/2]
+  // ApproachFunc: [time, pivot] -> [0 - 1]
+  // Pivot value is more or less when the animation seriously starts to slow down
+  const ApproachFunc = (tMs, pivoMs) => 2 * Math.atan(tMs / pivoMs) / PI;
+
+  // rfa and before are global and not associated to any state. They are used
+  // to drive the progressbar animation. There's only one animation to play
+  // at the same time.
+  let rfa = -1;
+  let before = 0;
+
+  const ProgressBar = Component([{
+    step(now) {
+      const viewer = this.props.webViewerCursor;
+
+      let progress; // value between 0 and 1
+
+      if (viewer.get('isLoading')) {                                            // Zone A
+        const startLoadingTime = viewer.get('startLoadingTime');
+        if (viewer.get('isConnecting')) {
+          progress = A * ApproachFunc(now - startLoadingTime, APivot);
+        } else {                                                                // Zone B
+          const connectedAt = viewer.get('connectedAt');
+          const A_offset = A * ApproachFunc(connectedAt - startLoadingTime, APivot);
+          progress = A_offset + B * ApproachFunc(now - connectedAt, BPivot);
+        }
+      } else {                                                                  // Zone C
+        let lastProgress = viewer.get('progress');
+        if (lastProgress < 1) {
+          progress = lastProgress + (now - before) * CSpeed;
+        } else {
+          progress = 1;
+        }
+      }
+
+      progress = Math.min(1, progress);
+      if (progress < 1) {
+        rfa = requestAnimationFrame(now => this.step(now));
+      } else {
+        rfa = -1;
+      }
+      before = now;
+      this.props.webViewerCursor = viewer.merge({progress});
+    },
+    componentDidUpdate() {
+      if (this.props.webViewerCursor.get('progress') < 1) {
+        if (rfa < 0) {
+          rfa = requestAnimationFrame(now => this.step(now));
+        }
+      } else {
+        cancelAnimationFrame(rfa);
+        rfa = -1;
+      }
+    }
+  }], ({key, webViewerCursor, theme}) => {
+    const progress = webViewerCursor.get('progress');
+    const translateX = 500 * (progress - 1);
+    const opacity = progress < StartFading  ? 1 : 1 - Math.pow( (progress - StartFading) / (1 - StartFading), 1);
+    return ProgressBarElement({
+      key,
+      className: 'progressbar',
+      progressBarColor: theme.progressbar.color,
+      style: {
+        transform: `translateX(${translateX}px)`,
+        opacity: opacity
+      }});
+  })
+
+
+  // Exports:
+
+  exports.ProgressBar = ProgressBar;
+
+});

--- a/src/browser/theme.js
+++ b/src/browser/theme.js
@@ -23,7 +23,8 @@ define((require, exports, module) => {
     titleText: {color: 'rgba(0,0,0,0.5)'},
     pageInfoText: {color: 'rgba(0,0,0,0.5)'},
     tabstrip: {backgroundColor: '#fff'},
-    navigationPanel: {backgroundColor: '#fff'}
+    navigationPanel: {backgroundColor: '#fff'},
+    progressbar: {color: '#82D3FD'}
   });
 
   const IS_DARK = true;
@@ -72,7 +73,8 @@ define((require, exports, module) => {
     titleText: {color: foregroundColor},
     pageInfoText: {color: foregroundColor},
     tabstrip: {backgroundColor: backgroundColor},
-    navigationPanel: {backgroundColor: backgroundColor}
+    navigationPanel: {backgroundColor: backgroundColor},
+    progressbar: {color: foregroundColor}
   });
 
   // Derive theme object from webViewer object.

--- a/src/browser/web-viewer/actions.js
+++ b/src/browser/web-viewer/actions.js
@@ -16,7 +16,13 @@ define((require, exports, module) => {
     // 'loading'|'loaded'|'stop'|'reload'|'goBack'|'goForward'
     readyState: null,
     // `true` if web content is currently loading.
-    loading: false,
+    isLoading: false,
+    // Position of the progressbar (0..1)
+    progress: 1,
+    // Has the server replied yet
+    isConnecting: false,
+    // When the server replied first (while loading)
+    connectedAt: null,
     // `true` if web content has a focus.
     isFocused: false,
     // `true` if this is currently active web viewer, in other words


### PR DESCRIPTION
issue #72. Please only look at the last commit (`wip`).

This is still WIP. But I need to know if this is the right approach.

Here is how it works:

The progressbar is split in 3 zones: **`[ aaa bbbb ccccccc]`**.

Zone **A** (~10% of the locationbar), is blue as soon as we start loading a page.
Zone **B** (~40% of the locationbar), is slowly incremented as the page is loading (see explanation below).
Zone **C** (~50%, rest of the locationbar), is filled once the page is fully loaded.

Zone **B** is updated every time gecko tells us there's a progression. But we *do not* use at the values of the progress event (see #72). So the bar moves only if there's activity, and its position is defined by a invert tangent function of loading time, which means as time pass, less and less pixels are added to the bar, which make it impossible to actually fill the all 40% reserved for this zone.

Patch is not finished. There are issues with tab switching. But before finishing it, I'd appreciate some feedback.

@gordonbrander ?