### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 node_modules/


### PR DESCRIPTION
Add .DS_Store to .gitignore. .DS_Store is one of those junk OSX files. I'm tired of seeing them show up in
the commit staging list.