### PR TITLE
Fix interactable gap between thumbnails

### DIFF
--- a/css/tabstrip.css
+++ b/css/tabstrip.css
@@ -48,15 +48,22 @@ main.showtabstrip iframes {
 }
 
 .tab {
-  margin: 15px 0 0;
-  height: 62.5px;
+  /* Keep buffer space around the visual thumbnail to make them easier
+  to click. */
+  height: 100px;
   width: 100px;
+}
+
+.tab-thumb {
+  background: white;
+  background-size: 100% auto;
   border: 1px solid rgba(0,0,0,0.07);
   border-radius: 4px;
-  background-color: white;
+  height: 62.5px;
+  margin: 16px 0 0;
   transform: scale(0.8);
   transition: transform 150ms ease;
-  background-size: 100% 100%;
+  width: 100px;
 }
 
 .tab:first-of-type {
@@ -67,10 +74,10 @@ main.showtabstrip iframes {
   margin-right: 0;
 }
 
-.tab:hover {
+.tab:hover > .tab-thumb {
   transform: scale(1);
 }
 
-.tabstrip:not(:hover) .tab.selected {
+.tabstrip:not(:hover) .tab.selected > .tab-thumb {
   transform: scale(1);
 }

--- a/css/tabstrip.css
+++ b/css/tabstrip.css
@@ -54,7 +54,7 @@ main.showtabstrip iframes {
   width: 100px;
 }
 
-.tab-thumb {
+.tab-thumbnail {
   background: white;
   background-size: 100% auto;
   border: 1px solid rgba(0,0,0,0.07);
@@ -74,10 +74,10 @@ main.showtabstrip iframes {
   margin-right: 0;
 }
 
-.tab:hover > .tab-thumb {
+.tab:hover .tab-thumbnail {
   transform: scale(1);
 }
 
-.tabstrip:not(:hover) .tab.selected > .tab-thumb {
+.tabstrip:not(:hover) .tab.selected .tab-thumbnail {
   transform: scale(1);
 }

--- a/src/browser/page-switch.js
+++ b/src/browser/page-switch.js
@@ -22,9 +22,6 @@ define((require, exports, moudle) => {
       key: `tab-${item.get('id')}`,
       className: 'tab' +
                  (item.get('isSelected') ? ' selected' : ''),
-      style: {
-        backgroundImage: readThumbnailURI(item.get('location'))
-      },
       onMouseDown: event => select(items, equals(item)),
       onMouseUp: event => {
         if (event.button == 1) {
@@ -32,7 +29,13 @@ define((require, exports, moudle) => {
           remove(items, equals(item));
         }
       }
-    }));
+    }, [
+      DOM.span({
+        key: `thumb-${item.get('id')}`,
+        className: 'tab-thumb',
+        style: {backgroundImage: readThumbnailURI(item.get('location'))},
+      })
+    ]));
   Tab.Deck = Deck(Tab);
 
 

--- a/src/browser/page-switch.js
+++ b/src/browser/page-switch.js
@@ -31,8 +31,8 @@ define((require, exports, moudle) => {
       }
     }, [
       DOM.span({
-        key: `thumb-${item.get('id')}`,
-        className: 'tab-thumb',
+        key: 'thumbnail',
+        className: 'tab-thumbnail',
         style: {backgroundImage: readThumbnailURI(item.get('location'))},
       })
     ]));


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/64

Also increases interactable area of thumbnails.

Note that I first tried using only CSS (`::after` and `attr()`) to solve this problem, but our support of CSS generated is too limited to pull this off. So instead, I added an element.