### PR TITLE
Always show tab strip on location hover

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -112,8 +112,7 @@ define((require, exports, module) => {
     const tabStripCursor = immutableState.cursor('tabStrip');
     const inputCursor = immutableState.cursor('input');
 
-    const isTabStripVisible = tabStripCursor.get('isActive') &&
-                              webViewersCursor.count() > 1;
+    const isTabStripVisible = tabStripCursor.get('isActive');
 
     const theme = readTheme(selectedWebViewerCursor);
 


### PR DESCRIPTION
Even if there is only one website. Closes
https://github.com/mozilla/browser.html/issues/131.