### PR TITLE
Move progress bar below tabstrip

### DIFF
--- a/css/locationbar.css
+++ b/css/locationbar.css
@@ -6,7 +6,6 @@
   border-radius: 3px;
   line-height: 30px;
   background-color: rgba(0,0,0,0.07);
-  position: relative;
   overflow: hidden;
 }
 
@@ -17,12 +16,11 @@
 .progressbar {
   z-index: 99;
   display: block;
-  width: 500px;
-  height: 30px;
-  background-image: linear-gradient(110deg, var(--progressbar-color), var(--progressbar-color) 460px, transparent 460px);
-  background-size: 500px 30px;
+  width: 100%;
+  height: 3px;
+  margin-left: -100%;
   position: absolute;
-  top: 0;
+  top: 40px;
   left: 0;
 }
 

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -2,6 +2,7 @@
   background-color: inherit;
   -moz-window-dragging: drag;
   padding: 5px;
+  position: relative;
   justify-content: space-between;
   scroll-snap-coordinate: 0 0;
   transition: background-color 200ms ease;

--- a/src/browser/progressbar.js
+++ b/src/browser/progressbar.js
@@ -92,14 +92,14 @@ define((require, exports, module) => {
     }
   }], ({key, webViewerCursor, theme}) => {
     const progress = webViewerCursor.get('progress');
-    const translateX = 500 * (progress - 1);
+    const percentProgress = 100 * progress;
     const opacity = progress < StartFading  ? 1 : 1 - Math.pow( (progress - StartFading) / (1 - StartFading), 1);
     return ProgressBarElement({
       key,
       className: 'progressbar',
-      progressBarColor: theme.progressbar.color,
       style: {
-        transform: `translateX(${translateX}px)`,
+        backgroundColor: theme.progressbar.color,
+        transform: `translateX(${percentProgress}%)`,
         opacity: opacity
       }});
   })


### PR DESCRIPTION
This approach is pretty generic, but solves a lot of the color matching
issues. Could use as an interim fix. Fixes
https://github.com/mozilla/browser.html/issues/115 and
https://github.com/mozilla/browser.html/issues/152