### PR TITLE
Make tab switching multi-platform

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ require.config({
     browser: '../src/browser',
     shims: '../src/shims',
     lang: '../src/lang',
+    os: '../src/os',
     // http://facebook.github.io/react/
     react: 'react/dist/react',
     // http://facebook.github.io/immutable-js/

--- a/src/browser/actions.js
+++ b/src/browser/actions.js
@@ -36,10 +36,6 @@ define((require, exports, module) => {
   // Creates a blank session. Returns immutable map.
   const resetSession = () => fromJS({
     isDocumentFocused: document.hasFocus(),
-    os: navigator.platform.startsWith('Win') ? 'windows' :
-    navigator.platform.startsWith('Mac') ? 'osx' :
-    navigator.platform.startsWith('Linux') ? 'linux' :
-    '',
     input: {value: '', isFocused: false},
     tabStrip: {isActive: false},
     webViewers: [open({isSelected: true,

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -94,7 +94,33 @@ define((require, exports, module) => {
   const onSelectNext = throttle(edit(selectNext), 200)
   const onSelectPrevious = throttle(edit(selectPrevious), 200);
 
-  const switchToTab = index => items => maybeActivateIndex(items, index);
+  const switchTab = (items, to) =>
+    to ? activate(select(items, to)) : items;
+
+  switchTab.toIndex = index => items => switchTab(items, items.get(index));
+  switchTab.toLast = items => switchTab(items, items.last());
+
+
+  let onTabSwitch;
+  {
+    const os = navigator.platform.startsWith('Win') ? 'windows' :
+               navigator.platform.startsWith('Mac') ? 'osx' :
+               navigator.platform.startsWith('Linux') ? 'linux' :
+               '';
+    const modifier = os == 'osx' ? 'meta' : 'alt';
+
+    onTabSwitch = KeyBindings({
+      [`${modifier} 1`]: edit(switchTab.toIndex(0)),
+      [`${modifier} 2`]: edit(switchTab.toIndex(1)),
+      [`${modifier} 3`]: edit(switchTab.toIndex(2)),
+      [`${modifier} 4`]: edit(switchTab.toIndex(3)),
+      [`${modifier} 5`]: edit(switchTab.toIndex(4)),
+      [`${modifier} 6`]: edit(switchTab.toIndex(5)),
+      [`${modifier} 7`]: edit(switchTab.toIndex(6)),
+      [`${modifier} 8`]: edit(switchTab.toIndex(7)),
+      [`${modifier} 9`]: edit(switchTab.toLast),
+    });
+  };
 
   const onDeckBinding = KeyBindings({
     'accel t': edit(openTab),
@@ -105,15 +131,6 @@ define((require, exports, module) => {
     'meta shift [': onSelectPrevious,
     'ctrl pagedown': onSelectNext,
     'ctrl pageup': onSelectPrevious,
-    'alt 1': edit(switchToTab(0)),
-    'alt 2': edit(switchToTab(1)),
-    'alt 3': edit(switchToTab(2)),
-    'alt 4': edit(switchToTab(3)),
-    'alt 5': edit(switchToTab(4)),
-    'alt 6': edit(switchToTab(5)),
-    'alt 7': edit(switchToTab(6)),
-    'alt 8': edit(switchToTab(7)),
-    'alt 9': edit(activateLast),
   });
 
   const onDeckBindingRelease = KeyBindings({
@@ -163,6 +180,7 @@ define((require, exports, module) => {
                                  onTabStripKeyDown(tabStripCursor),
                                  onViewerBinding(selectedWebViewerCursor),
                                  onDeckBinding(webViewersCursor),
+                                 onTabSwitch(webViewersCursor),
                                  onBrowserBinding(immutableState)),
       onDocumentKeyUp: compose(onTabStripKeyUp(tabStripCursor),
                                onDeckBindingRelease(webViewersCursor))

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -24,12 +24,12 @@ define((require, exports, module) => {
          maybeActivateIndex, activateLast} = require('./deck/actions');
   const {readTheme} = require('./theme');
   const ClassSet = require('./util/class-set');
+  const os = require('os');
 
   const getOwnerWindow = node => node.ownerDocument.defaultView;
   // Define custom `main` element with a custom `scrollGrab` attribute
   // that maps to same named proprety.
   const Main = Element('main', {
-    os: Attribute('os'),
     windowTitle: VirtualAttribute((node, current, past) => {
       node.ownerDocument.title = current;
     }),
@@ -103,11 +103,7 @@ define((require, exports, module) => {
 
   let onTabSwitch;
   {
-    const os = navigator.platform.startsWith('Win') ? 'windows' :
-               navigator.platform.startsWith('Mac') ? 'osx' :
-               navigator.platform.startsWith('Linux') ? 'linux' :
-               '';
-    const modifier = os == 'osx' ? 'meta' : 'alt';
+    const modifier = os.platform() == 'darwin' ? 'meta' : 'alt';
 
     onTabSwitch = KeyBindings({
       [`${modifier} 1`]: edit(switchTab.toIndex(0)),
@@ -163,7 +159,6 @@ define((require, exports, module) => {
     const theme = readTheme(activeWebViewerCursor);
 
     return Main({
-      os: immutableState.get('os'),
       windowTitle: title(selectedWebViewerCursor),
       scrollGrab: true,
       className: ClassSet({

--- a/src/browser/deck/actions.js
+++ b/src/browser/deck/actions.js
@@ -196,14 +196,6 @@ define((require, exports, module) => {
 
   const prepend = (items, item) => insert(items, item, 0);
 
-  const maybeActivateIndex = (items, index) => {
-    return index <  items.length
-      ? activate(switchSelected(items, indexOfSelected(items), index))
-      : items;
-  }
-
-  const activateLast = items => maybeActivateIndex(items, items.length - 1);
-
   // Exports:
 
   exports.isSelected = isSelected;
@@ -214,8 +206,6 @@ define((require, exports, module) => {
   exports.select = select;
   exports.selectNext = selectNext;
   exports.selectPrevious = selectPrevious;
-  exports.maybeActivateIndex = maybeActivateIndex;
-  exports.activateLast = activateLast;
 
   exports.isActive = isActive;
   exports.asActive = asActive;

--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -6,10 +6,7 @@ define((require, exports, module) => {
 
   'use strict';
 
-  const os = navigator.platform.startsWith('Win') ? 'windows' :
-             navigator.platform.startsWith('Mac') ? 'osx' :
-             navigator.platform.startsWith('Linux') ? 'linux' :
-             '';
+  const platform = require('os').platform();
 
   const readModifiers = ({type, metaKey, shiftKey, altKey, ctrlKey}) => {
     const modifiers = [];
@@ -36,7 +33,7 @@ define((require, exports, module) => {
   const readKey = key => readKey.table[key] || key;
   readKey.table = Object.assign(Object.create(null), {
     'ctrl': 'control',
-    'accel': os == 'osx' ? 'meta' : 'control',
+    'accel': platform == 'darwin' ? 'meta' : 'control',
     'ArrowLeft': 'left',
     'ArrowRight': 'right',
     'ArrowUp': 'up',

--- a/src/os.js
+++ b/src/os.js
@@ -1,0 +1,12 @@
+// Subset of `os` module from node.js and io.js:
+// https://iojs.org/api/os.html
+define((require, exports, module) => {
+  const platform = navigator.platform.startsWith('Win') ? 'win32' :
+                   navigator.platform.startsWith('Mac') ? 'darwin' :
+                   navigator.platform.startsWith('Linux') ? 'linux' :
+                   navigator.platform.startsWith('FreeBSD') ? 'freebsd' :
+                   navigator.platform;
+
+  // https://iojs.org/api/os.html#os_os_platform
+  exports.platform = () => platform;
+});


### PR DESCRIPTION
- Remove obsolete deck actions.
- Generate diff bindings based on platform.