### PR TITLE
Implement tab ordering by switch time.

### DIFF
--- a/src/browser/actions.js
+++ b/src/browser/actions.js
@@ -70,8 +70,6 @@ define((require, exports, module) => {
     tabStripCursor.set('isActive', true);
   exports.hideTabStrip = tabStripCursor =>
     tabStripCursor.set('isActive', false);
-  exports.resetSelected = webViewersCursor =>
-    webViewersCursor.update(items => select(items, active(items)));
   exports.resetSession = resetSession;
   exports.readSession = readSession;
   exports.writeSession = writeSession;

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -19,8 +19,8 @@ define((require, exports, module) => {
   const {focus, showTabStrip, hideTabStrip,
          writeSession, resetSession, resetSelected} = require('./actions');
   const {indexOfSelected, indexOfActive, isActive,
-         selectNext, selectPrevious, select, activate, commit,
-         previewed, remove, append} = require('./deck/actions');
+         selectNext, selectPrevious, select, activate,
+         reorder, reset, previewed, remove, append} = require('./deck/actions');
   const {readTheme} = require('./theme');
   const ClassSet = require('./util/class-set');
   const os = require('os');
@@ -129,8 +129,8 @@ define((require, exports, module) => {
   });
 
   const onDeckBindingRelease = KeyBindings({
-    'control': commit,
-    'meta': commit
+    'control': edit(compose(reorder, activate)),
+    'meta': edit(compose(reorder, activate))
   });
 
   const onBrowserBinding = KeyBindings({
@@ -206,7 +206,7 @@ define((require, exports, module) => {
                className: 'tabstripkillzone',
                onMouseEnter: event => {
                  hideTabStrip(tabStripCursor);
-                 webViewersCursor.update(commit.reset);
+                 webViewersCursor.update(compose(reorder, reset));
                }
               }),
 

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -19,9 +19,8 @@ define((require, exports, module) => {
   const {focus, showTabStrip, hideTabStrip,
          writeSession, resetSession, resetSelected} = require('./actions');
   const {indexOfSelected, indexOfActive, isActive,
-         selectNext, selectPrevious, select, activate,
-         previewed, remove, append,
-         maybeActivateIndex, activateLast} = require('./deck/actions');
+         selectNext, selectPrevious, select, activate, commit,
+         previewed, remove, append} = require('./deck/actions');
   const {readTheme} = require('./theme');
   const ClassSet = require('./util/class-set');
   const os = require('os');
@@ -130,8 +129,8 @@ define((require, exports, module) => {
   });
 
   const onDeckBindingRelease = KeyBindings({
-    'control': activate,
-    'meta': activate
+    'control': commit,
+    'meta': commit
   });
 
   const onBrowserBinding = KeyBindings({
@@ -206,8 +205,8 @@ define((require, exports, module) => {
       DOM.div({key: 'tabstripkillzone',
                className: 'tabstripkillzone',
                onMouseEnter: event => {
-                 resetSelected(webViewersCursor);
                  hideTabStrip(tabStripCursor);
+                 webViewersCursor.update(commit.reset);
                }
               }),
 

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -120,8 +120,8 @@ define((require, exports, module) => {
   const onDeckBinding = KeyBindings({
     'accel t': edit(openTab),
     'accel w': edit(close(isActive)),
-    'control tab': onSelectNext,
-    'control shift tab': onSelectPrevious,
+    'control tab': onSelectPrevious,
+    'control shift tab': onSelectNext,
     'meta shift ]': onSelectNext,
     'meta shift [': onSelectPrevious,
     'ctrl pagedown': onSelectNext,

--- a/src/browser/deck.js
+++ b/src/browser/deck.js
@@ -8,11 +8,13 @@ define((require, exports, module) => {
   const {DOM} = require('react');
   const Component = require('omniscient');
 
-  const Deck = Item => Component('Deck', (options, handlers) =>
-    DOM.div(options, options.items.map(item => Item({
+  const Deck = (Item, order) => Component('Deck', (options, handlers) => {
+    const items = order ? options.items.sortBy(order) : options.items;
+    return DOM.div(options, items.map(item => Item({
       key: item.get('id'),
       item
-    }, handlers))));
+    }, handlers)))
+  });
 
   // Exports:
 

--- a/src/browser/deck.js
+++ b/src/browser/deck.js
@@ -12,6 +12,11 @@ define((require, exports, module) => {
     const items = order ? options.items.sortBy(order) : options.items;
     return DOM.div(options, items.map(item => Item({
       key: item.get('id'),
+      // Hack to force re-rendering when items get re-arranged, workaround
+      // for a following bugs:
+      // https://github.com/omniscientjs/omniscient/issues/89
+      // https://github.com/facebook/immutable-js/issues/370
+      index: options.items.indexOf(item),
       item
     }, handlers)))
   });

--- a/src/browser/deck/actions.js
+++ b/src/browser/deck/actions.js
@@ -102,7 +102,23 @@ define((require, exports, module) => {
     const to = indexOfSelected(items);
 
     return switchActive(items, from, to);
-  }
+  };
+
+  // Resets currently selecetd tab back to the active one.
+  const reset = items => select(items, active(items));
+
+  // Takes deck `items` and activates selected item if that's not
+  // already a case & stores current time stapm into active item's
+  // `switchTime`.
+  const commit = compose(items => {
+    const index = indexOfActive(items);
+    return items.updateIn([index, 'switchTime'], Date.now);
+  }, activate);
+
+  // Resets currently selected item back to the active one and
+  // updates `switchTime` on active item.
+  commit.reset = compose(commit, reset);
+
 
   const activateNext = compose(activate, selectNext);
   const activatePrevious = compose(activate, selectPrevious);
@@ -215,6 +231,7 @@ define((require, exports, module) => {
   exports.activate = activate;
   exports.activateNext = activateNext;
   exports.activatePrevious = activatePrevious;
+  exports.commit = commit;
 
   exports.remove = remove;
   exports.insert = insert;

--- a/src/browser/deck/actions.js
+++ b/src/browser/deck/actions.js
@@ -113,11 +113,16 @@ define((require, exports, module) => {
   const makeFirst = (items, item) =>
     items.sort((a, b) => item === a ? -1 :
                          item === b ? 1 :
-                         -1);
+                         0);
+
+  const makeLast = (items, item) =>
+    items.sort((a, b) => item === a ? 1 :
+                         item === b ? -1 :
+                         0);
 
   // Reorders given `items` such that active item will be moved
-  // to the head of it.
-  const reorder = items => makeFirst(items, active(items));
+  // to the tail of it.
+  const reorder = items => makeLast(items, active(items));
 
 
   const activateNext = compose(activate, selectNext);

--- a/src/browser/deck/actions.js
+++ b/src/browser/deck/actions.js
@@ -107,17 +107,17 @@ define((require, exports, module) => {
   // Resets currently selecetd tab back to the active one.
   const reset = items => select(items, active(items));
 
-  // Takes deck `items` and activates selected item if that's not
-  // already a case & stores current time stapm into active item's
-  // `switchTime`.
-  const commit = compose(items => {
-    const index = indexOfActive(items);
-    return items.updateIn([index, 'switchTime'], Date.now);
-  }, activate);
 
-  // Resets currently selected item back to the active one and
-  // updates `switchTime` on active item.
-  commit.reset = compose(commit, reset);
+  // Reorders `items` such that given `item` will be first and
+  // rest items will remain as they were.
+  const makeFirst = (items, item) =>
+    items.sort((a, b) => item === a ? -1 :
+                         item === b ? 1 :
+                         -1);
+
+  // Reorders given `items` such that active item will be moved
+  // to the head of it.
+  const reorder = items => makeFirst(items, active(items));
 
 
   const activateNext = compose(activate, selectNext);
@@ -231,7 +231,8 @@ define((require, exports, module) => {
   exports.activate = activate;
   exports.activateNext = activateNext;
   exports.activatePrevious = activatePrevious;
-  exports.commit = commit;
+  exports.reorder = reorder;
+  exports.reset = reset;
 
   exports.remove = remove;
   exports.insert = insert;

--- a/src/browser/page-switch.js
+++ b/src/browser/page-switch.js
@@ -42,7 +42,7 @@ define((require, exports, moudle) => {
         className: "tab-close-button fa fa-times",
       })
     ]));
-  Tab.Deck = Deck(Tab);
+  Tab.Deck = Deck(Tab, tab => tab.get('switchTime') * -1);
 
   // Exports:
 

--- a/src/browser/page-switch.js
+++ b/src/browser/page-switch.js
@@ -42,7 +42,7 @@ define((require, exports, moudle) => {
         className: "tab-close-button fa fa-times",
       })
     ]));
-  Tab.Deck = Deck(Tab, tab => tab.get('switchTime') * -1);
+  Tab.Deck = Deck(Tab);
 
   // Exports:
 

--- a/src/browser/web-viewer.js
+++ b/src/browser/web-viewer.js
@@ -136,7 +136,9 @@ define((require, exports, module) => {
     }
   }
 
-  WebViewer.Deck = Deck(WebViewer);
+  // WebViewer deck will always inject frames by order of their id. That way
+  // no iframes will need to be removed / injected when order of tabs change.
+  WebViewer.Deck = Deck(WebViewer, item => item.get('id'));
   // Exports:
 
   exports.WebViewer = WebViewer;


### PR DESCRIPTION
# Work in progress

- [x] Order tabs by recent switch
- [x] navigation between tabs by switch recency.

**P.S.:** This change depends on new fields in data model so in order for you tabs to start render in right order you'd need to activate each one or reset session with `cmd shift backspace`