### PR TITLE
Update mechanism

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -42,6 +42,11 @@
 
 /* Let's use flexbox everywhere */
 
+body {
+  height: 100vh;
+  overflow: hidden;
+}
+
 main {
   height: 100vh;
   width: 100vw;

--- a/css/updatebanner.css
+++ b/css/updatebanner.css
@@ -1,0 +1,35 @@
+.appupdatebanner {
+  display: flex;
+  position: absolute;
+  justify-content: space-between;
+  bottom: 10px;
+  width: 300px;
+  left: calc(50vw - 150px);
+  background-color: rgba(36,60,83,0.95);
+  border-radius: 4px;
+  padding: 8px 8px 8px 20px;
+  color: white;
+  align-items: center;
+  transition: transform 500ms ease-in;
+}
+
+.appupdatebanner:not(.active) {
+  transform: translateY(200px);
+}
+
+.appupdatebanner > span {
+  font-weight: 100;
+  cursor: default;
+}
+
+.appupdatebutton {
+  background-color: rgb(115,206,113);
+  padding: 8px 20px;
+  font-weight: 100;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.appupdatebutton:hover {
+  background-color: rgb(115,216,113);
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <link rel='stylesheet' title='default' href='css/dashboard.css'>
     <link rel='stylesheet' title='default' href='css/window_controls.css'>
     <link rel='stylesheet' title='default' href='css/awesomebar.css'>
+    <link rel='stylesheet' title='default' href='css/updatebanner.css'>
 
 
     <!-- Module handling -->

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -41,7 +41,8 @@ define((require, exports, module) => {
     onDocumentBlur: Event('blur', getOwnerWindow),
     onDocumentKeyDown: Event('keydown', getOwnerWindow),
     onDocumentKeyUp: Event('keyup', getOwnerWindow),
-    onDocumentUnload: Event('unload', getOwnerWindow)
+    onDocumentUnload: Event('unload', getOwnerWindow),
+    onAppUpdateAvailable: Event('app-update-available', getOwnerWindow)
   });
 
   const onNavigation = KeyBindings({
@@ -177,7 +178,8 @@ define((require, exports, module) => {
 
     const suggestionsCursor = immutableState.cursor('suggestions');
 
-    return Main({
+    return DOM.div({
+    }, [Main({
       windowTitle: title(selectedWebViewerCursor),
       scrollGrab: true,
       className: ClassSet({
@@ -197,7 +199,8 @@ define((require, exports, module) => {
                                  onTabSwitch(webViewersCursor),
                                  onBrowserBinding(immutableState)),
       onDocumentKeyUp: compose(onTabStripKeyUp(tabStripCursor),
-                               onDeckBindingRelease(webViewersCursor))
+                               onDeckBindingRelease(webViewersCursor)),
+      onAppUpdateAvailable: event => immutableState.set('appUpdateAvailable', true),
     }, [
       NavigationPanel({
         key: 'navigation',
@@ -255,8 +258,22 @@ define((require, exports, module) => {
         onClose: item => webViewersCursor.update(closeTab(item)),
         onOpen: item => webViewersCursor.update(addTab(item))
       })
-    ]);
-  });
+    ]),
+    DOM.div({
+      key: 'appUpdateBanner',
+      className: ClassSet({
+        appupdatebanner: true,
+        active: immutableState.get('appUpdateAvailable')
+      }),
+    }, [
+      'Hey! An update just for you!',
+      DOM.div({
+        key: 'appUpdateButton',
+        className: 'appupdatebutton',
+        onClick: e => window.location.reload(true)
+      }, 'Apply')
+    ])]);
+  })
   // Create a version of readTheme that will return from cache
   // on repeating calls with an equal cursor.
   Browser.readTheme = Component.cached(readTheme);

--- a/src/browser/github.js
+++ b/src/browser/github.js
@@ -1,0 +1,69 @@
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+
+  'use strict';
+
+  const API = 'https://api.github.com/repos/mozilla/browser.html/events';
+  const REF = 'refs/heads/gh-pages';
+  const MIN_INTERVAL = 60000;
+  const knownEvents = new Set();
+
+  let etag;
+  let interval = MIN_INTERVAL;
+  let pulling = false;
+
+  const pull = () => {
+    pulling = true;
+    let headers = {};
+    if (etag) {
+      headers = { "If-None-Match": etag }
+    }
+    fetch(API, { headers }).then(response => {
+      if (response.status == 200) {
+        console.log('github: new events');
+        let xPoll = response.headers.get('X-Poll-Interval');
+        etag = response.headers.get('ETag');
+        if (xPoll) {
+          interval = Math.max(xPoll * 1000, MIN_INTERVAL);
+        }
+        response.json().then((allEvents) => {
+          // Basic check. If there's an unknown push event, update!
+          const unkownEvents = allEvents.filter(e => e.type == 'PushEvent')
+                                        .filter(e => !knownEvents.has(e.id));
+          // Because initially we don't have any know events, let's use the
+          // first events as a record of what happened in the past. We will
+          // obviously miss events, so we need to save the latest known
+          // events/commits/whatever, but we'll do that once we know exactly
+          // how we want to handle updates (probably in a service worker).
+          if (knownEvents.size > 0) {
+            if (unkownEvents.some(e => e.payload.ref == REF)) {
+              console.log('github: new push to gh-pages');
+              window.dispatchEvent(new CustomEvent("app-update-available"));
+            }
+          }
+          unkownEvents.forEach(e => knownEvents.add(e.id));
+        });
+      }
+      if (response.status == 304) {
+        console.log('github: no events');
+      }
+      if (response.status != 200 && response.status != 304) {
+        console.error("Unexpected status", response.status, response.statusText);
+      }
+      console.log(`pulling in ${interval}ms`);
+      setTimeout(pull, interval);
+    }).catch(error => {
+      console.error("fetch error", error);
+      console.log(`pulling in ${interval}ms`);
+      setTimeout(pull, interval);
+    });
+  };
+
+
+  pull();
+
+});

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -6,12 +6,15 @@ define((require, exports, module) => {
 
   'use strict';
 
+  require('./github'); // Pull updates from github
+
   const {render} = require('./core');
   const {Browser} = require('./browser');
   const {readSession, resetSession} = require('./actions');
 
   // See issue #218
-  // render(Browser, readSession() || resetSession(), document.body);
-  render(Browser, resetSession(), document.body);
+  let session = readSession() || resetSession();
+  session = session.set('appUpdateAvailable', false);
+  render(Browser, session , document.body);
 
 });


### PR DESCRIPTION
Addressing issue #209

This is the first part. It's very basic, but good enough for a demo:

Github event API end point is pulled every 60 seconds, or longer, depending on what the server answers. We check if there's any new push to `gh-pages`, if there is, we show a banner with a `location.reload(true)` button. That's it.

A better strategy is necessary, but we're not there yet.