### PR TITLE
Add new tab style

### DIFF
--- a/css/tabstrip.css
+++ b/css/tabstrip.css
@@ -103,3 +103,32 @@
   transition: opacity 150ms 250ms ease;
   pointer-events: auto;
 }
+
+.tab-dashboard .tab-thumbnail {
+  background: transparent;
+  border: 1px solid rgba(0,0,0,0.1);
+}
+
+.tab-dashboard .tab-thumbnail::after {
+  color: rgba(0,0,0,0.2);
+  content: "\f067";
+  cursor: default;
+  display: block;
+  font: 24px/62.5px FontAwesome;
+  text-align: center;
+  vertical-align: middle;
+  width: 100%;
+}
+
+.tab-dashboard .tab-thumbnail {
+  background: transparent;
+  border: 1px solid rgba(0,0,0,0.1);
+}
+
+.isdark .tab-dashboard .tab-thumbnail::after {
+  color: rgba(255,255,255,0.4);
+}
+
+.isdark .tab-dashboard .tab-thumbnail {
+  border: 1px solid rgba(255,255,255,0.2);
+}

--- a/src/browser/page-switch.js
+++ b/src/browser/page-switch.js
@@ -18,7 +18,9 @@ define((require, exports, moudle) => {
     return DOM.div({
       className: ClassSet({
         tab: true,
-        selected: isSelected(webViewerCursor)
+        selected: isSelected(webViewerCursor),
+        // Currently "pinned" is a proxy for the dashboard tab
+        'tab-dashboard': webViewerCursor.get('isPinned')
       }),
       style: { order: order },
       onMouseOver: event => onSelect(webViewerCursor),


### PR DESCRIPTION
Initial new tab style. It's not perfect, but it's better than what we had.

We unified the concept of "dashboard", "new tab", "add tab" into a single model. I prefer the "+" analogy to something like a home icon because it is the most immediately aligned with a new user's interest ("I want a new tab"), with the discovery of the dashboard being a happy result.