### PR TITLE
Selection state should be updated both ways.

### DIFF
--- a/src/browser/actions.js
+++ b/src/browser/actions.js
@@ -108,7 +108,6 @@ define((require, exports, module) => {
   exports.readInputURL = readInputURL;
   exports.focus = focusable => focusable.set('isFocused', true);
   exports.blur = focusable => focusable.set('isFocused', false);
-  exports.select = editable => editable.set('selection', {all: true});
   exports.showTabStrip = tabStripCursor =>
     tabStripCursor.set('isActive', true);
   exports.hideTabStrip = tabStripCursor =>

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -17,11 +17,11 @@ define((require, exports, module) => {
   const {getDashboardThemePatch,
          readDashboardNavigationTheme} = require('./dashboard/actions');
   const {Element, Event, VirtualAttribute, Attribute} = require('./element');
+  const {select: selectField} = require('./editable');
   const {KeyBindings} = require('./keyboard');
   const {zoomIn, zoomOut, zoomReset, open,
          goBack, goForward, reload, stop, title} = require('./web-viewer/actions');
-  const {focus, showTabStrip, hideTabStrip, select: selectField,
-         readInputURL,
+  const {focus, showTabStrip, hideTabStrip, readInputURL,
          writeSession, resetSession, resetSelected} = require('./actions');
   const {indexOfSelected, indexOfActive, isActive, arrange,
          selectNext, selectPrevious, select, activate,

--- a/src/browser/editable.js
+++ b/src/browser/editable.js
@@ -11,37 +11,21 @@ define((require, exports, module) => {
   const {Component, createFactory} = require('react');
 
   const selection = VirtualAttribute((node, current, past) => {
-    if (current != past) {
-      if (!current) {
-        node.selectionStart = node.selectionEnd;
-      }
-      else if (current) {
-        const hasStart = 'start' in current;
-        const hasEnd = 'end' in current;
-        const isRange = hasStart || hasEnd;
+    past = past || {};
+    if (current !== past) {
+      if (current) {
+        const {start, end, direction} = current;
 
-        if (hasStart) {
-          node.selectionStart = current.start;
+        if (start !== past.start) {
+          node.selectionStart = start === Infinity ? node.value.length : start;
         }
 
-        if (hasEnd) {
-          node.selectionEnd = current.end;
+        if (end !== past.end) {
+          node.selectionEnd = end === Infinity ? node.value.length : end;
         }
 
-        if (!isRange) {
-          node.select();
-        }
-
-        if (current.direction == 'forward') {
-          node.selectionDirection = 'forward';
-        }
-
-        if (current.direction == 'backward') {
-          node.selectionDirection = 'backward';
-        }
-
-        if (current.direction == 'none') {
-          node.selectionDirection = 'none';
+        if (direction !== past.direction) {
+          node.selectionDirection = direction;
         }
       }
     }
@@ -77,5 +61,8 @@ define((require, exports, module) => {
 
   exports.selection = selection;
   exports.InputField = createFactory(InputField);
+
+  exports.select = (input, start=0, end=Infinity, direction='forward') =>
+    input.set('selection', {start, end, direction});
 
 });

--- a/src/browser/navigation-panel.js
+++ b/src/browser/navigation-panel.js
@@ -9,9 +9,9 @@ define((require, exports, module) => {
   const platform = require('os').platform();
   const {DOM} = require('react')
   const Component = require('omniscient');
-  const {InputField} = require('./editable');
+  const {InputField, select} = require('./editable');
   const {Element} = require('./element');
-  const {showTabStrip, blur, focus, select} = require('./actions');
+  const {showTabStrip, blur, focus} = require('./actions');
   const {KeyBindings} = require('./keyboard');
   const url = require('./util/url');
   const {ProgressBar} = require('./progressbar');
@@ -126,6 +126,13 @@ define((require, exports, module) => {
         onBlur: event => {
           resetSuggestions(suggestionsCursor);
           inputCursor.set('isFocused', false);
+        },
+        onSelect: event => {
+          inputCursor.set('selection', {
+            start: event.target.selectionStart,
+            end: event.target.selectionEnd,
+            direction: event.target.selectionDirection
+          });
         },
         onChange: event => {
           // Reset suggestions & compute new ones from the changed input value.


### PR DESCRIPTION
Sometimes you can end up in broken state where escaping the address bar is impossible. I believe it could be reproduced by pressing `cmd l` while in the location bar. I think this is also what issue #264 is about, but I maybe wrong.

Either way current problem is that keyboard shortcut will store `selection` state into a state that later is used to update selection in the input. The problem was that changes to the selection were never reflected in the state there for any re-render would select all of the text in the input over and over.

This patch cleans up a little how selection was implemented (it was hacked together without much of a thought) and wires both ends so that changes to selection are reflected in the state and changes in the state are reflected in the UI.