### PR TITLE
Prevent closing dashboard via cmd+w

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -107,8 +107,7 @@ define((require, exports, module) => {
   // This avoids code branching down the pipe that otherwise will
   // need to deal with 0 viewer & no active viewer case.
   const close = p => items =>
-    items.count() > 1 ? remove(items, p) :
-    items.set(0, open({isSelected: true, isActive: true}));
+    !isPinned(items.find(p)) ? remove(items, p) : items;
 
   const closeTab = id =>
     close(x => x.get('id') == id);


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/271

@Gozala I can also put together a follow-up that factors out `remove(items, p)` into `findAndRemove(items, p)` and `remove(items, item)`. That would be marginally more efficient since we wouldn't have to `find` twice.