### PR TITLE
Basic support for about:setting

### DIFF
--- a/css/locationbar.css
+++ b/css/locationbar.css
@@ -103,10 +103,18 @@
   font-weight: bold;
 }
 
-.navbar.ssl .pageurlsummary::before {
+.navbar.ssl .pageurlsummary::before,
+.navbar.privileged .pageurlsummary::before {
   font-family: FontAwesome;
   font-weight: normal;
-  content: "\f023";
   margin-right: 6px;
   vertical-align: middle;
+}
+
+.navbar.ssl .pageurlsummary::before {
+  content: "\f023";
+}
+
+.navbar.privileged .pageurlsummary::before {
+  content: "\f013";
 }

--- a/src/about/settings/index.html
+++ b/src/about/settings/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+  <!--
+
+      This Source Code Form is subject to the terms of the Mozilla Public
+      License, v. 2.0. If a copy of the MPL was not distributed with this
+      file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+  -->
+
+  <head>
+    <meta charset='utf-8'>
+    <title>about:settings</title>
+    <link rel='stylesheet' title='default' href='settings.css'>
+
+    <!-- Module handling -->
+    <!-- All further JS code is loaded from javascript -->
+    <script data-main='./main' src='../../../node_modules/requirejs/require.js'
+            type='text/javascript' defer='defer'></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/about/settings/index.js
+++ b/src/about/settings/index.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+
+  'use strict';
+
+  const Component = require('omniscient');
+  const {render} = require('browser/core');
+  const {DOM} = require('react');
+
+  const {Map} = require('immutable');
+  const Table = Component('Table', state => {
+
+    let rows = [];
+    for (let [name,value] of state) {
+      rows.push(DOM.div({
+        key: name,
+        className: 'row'
+      }, [
+        DOM.span({
+          key: 'name.' + name,
+          className: 'name',
+          title: name
+        }, name),
+        DOM.span({
+          key: 'value.' + name,
+          className: 'value',
+          title: value
+        }, value)
+      ]));
+    }
+
+    return DOM.div({
+      key: 'table',
+      className: 'table'
+    }, rows);
+
+  });
+
+  const table = render(Table, new Map(), document.body);
+
+  navigator.mozSettings
+           .createLock()
+           .get('*')
+           .then(r => table.step(state => state.merge(r)));
+
+  navigator.mozSettings.onsettingchange = e => {
+    table.step(state => state.set(e.settingName, e.settingValue));
+  }
+
+});

--- a/src/about/settings/main.js
+++ b/src/about/settings/main.js
@@ -1,0 +1,20 @@
+require.config({
+  scriptType: 'text/javascript;version=1.8',
+  baseUrl: '../../../node_modules/',
+  nodeIdCompat: true,
+  paths: {
+    settings: '../src/about/settings',
+    browser: '../src/browser',
+    shims: '../src/shims',
+    react: 'react/dist/react',
+    immutable: 'immutable/dist/immutable',
+    omniscient: 'omniscient/dist/omniscient',
+  },
+  shim: {
+    omniscient: {
+      deps: ['shims/omniscient']
+    }
+  }
+});
+
+require(['settings/index']);

--- a/src/about/settings/settings.css
+++ b/src/about/settings/settings.css
@@ -1,0 +1,17 @@
+body {
+  font-size: 12px;
+}
+
+.row {
+  border-bottom: 1px solid #DDD;
+  padding: 5px;
+  white-space: nowrap;
+}
+
+.name, .value {
+  display: inline-block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 300px;
+}

--- a/src/browser/actions.js
+++ b/src/browser/actions.js
@@ -18,10 +18,14 @@ define((require, exports, module) => {
   const makeSearchURL = input =>
     `https://duckduckgo.com/?q=${encodeURIComponent(input)}`;
 
+  const makeAboutURL = input =>
+    url.getBaseURI() + 'src/about/' + input.replace('about:', '') + '/index.html';
+
   const sendEventToChrome = type => dispatchEvent(new CustomEvent('mozContentEvent',
     { bubbles: true, cancelable: false, detail: { type }}))
 
   const readInputURL = input =>
+    url.isAboutURL(input) ? makeAboutURL(input) :
     url.isNotURL(input) ? makeSearchURL(input) :
     !url.hasScheme(input) ? `http://${input}` :
     input;

--- a/src/browser/element.js
+++ b/src/browser/element.js
@@ -102,6 +102,12 @@ define((require, exports, module) => {
     constructor: BeforeAppendAttribute,
     mount(node, value) {
       node.setAttribute(this.name, value);
+    },
+    write(node, present, past) {
+      Attribute.prototype.write.call(this, node, present, past)
+      if (present !== past) {
+        node.parentNode.replaceChild(node, node)
+      }
     }
   };
   Element.BeforeAppendAttribute = BeforeAppendAttribute;

--- a/src/browser/github.js
+++ b/src/browser/github.js
@@ -59,7 +59,7 @@ define((require, exports, module) => {
 
   const localHEAD = new Promise((resolve, reject) => {
     if (!PROD) {
-      return reject();
+      return reject('Not prod environment');
     }
     fetch('HEAD').then(response => {
       if (response.status == 200) {
@@ -68,6 +68,14 @@ define((require, exports, module) => {
         reject(`Can\'t reach HEAD: ${response.statusText}`);
       }
     }).catch(reject);
+  });
+
+  let lock = navigator.mozSettings.createLock();
+
+  localHEAD.then(hash => {
+    lock.set({'browserhtml.HEAD_HASH': hash});
+  }, e => {
+    lock.set({'browserhtml.HEAD_HASH': `unknown (${e})`});
   });
 
   const appUpdateAvailable = new Promise(pull);

--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -14,6 +14,7 @@ define((require, exports, module) => {
     isFocused: isFocused,
     isRemote: new BeforeAppendAttribute('remote'),
     isBrowser: new BeforeAppendAttribute('mozbrowser'),
+    mozApp: new BeforeAppendAttribute('mozapp'),
     allowFullScreen: new BeforeAppendAttribute('mozallowfullscreen'),
     src: VirtualAttribute((node, current, past) => {
       if (current != past) {

--- a/src/browser/navigation-panel.js
+++ b/src/browser/navigation-panel.js
@@ -182,7 +182,8 @@ define((require, exports, module) => {
         canreload: webViewer.get('location'),
         loading: webViewer.get('isLoading'),
         ssl: webViewer.get('securityState') == 'secure',
-        sslv: webViewer.get('securityExtendedValidation')
+        sslv: webViewer.get('securityExtendedValidation'),
+        privileged: url.isPrivileged(webViewer.get('location'))
       })
     }, [
       WindowControls({key: 'controls', theme}),

--- a/src/browser/util/url.js
+++ b/src/browser/util/url.js
@@ -37,6 +37,12 @@ define(function() {
       return this.a.origin;
     },
 
+    getBaseURI: function urlHelper_getBaseURI() {
+      // http://example.com/foo/index.html -> http://example.com/foo/
+      // http://example.com/foo/ -> http://example.com/foo/
+      return location.href.replace(/\/[^/]*$/, '/');
+    },
+
     getHostname: function urlHelper_getHostname(url) {
       this.a = this.a || document.createElement('a');
       this.a.href = url;
@@ -85,6 +91,23 @@ define(function() {
       }
       this.urlValidate.setAttribute('value', str);
       return !this.urlValidate.validity.valid;
+    },
+
+    isAboutURL: function(url) {
+      try {
+        return new URL(url).protocol == 'about:';
+      } catch(e) {
+        return false;
+      }
+    },
+
+    isPrivileged: function urlHelper_isPrivilegedURI(uri) {
+      // FIXME: not safe. White list?
+      return uri && uri.startsWith(this.getBaseURI() + 'src/about/');
+    },
+
+    getManifestURL: function urlHelper_getManifestURL() {
+      return this.getBaseURI() + 'manifest.webapp';
     },
 
     trim: function(input) {

--- a/src/browser/web-viewer.js
+++ b/src/browser/web-viewer.js
@@ -25,6 +25,7 @@ define((require, exports, module) => {
 
     // Do not render anything unless viewer has any `uri`
     if (!state.get('uri')) return null;
+
     return IFrame({
       className: ClassSet({
         'iframes-frame': true,
@@ -34,9 +35,9 @@ define((require, exports, module) => {
         // to workaround #266 & be able to capture screenshots.
         rendered: state.get('thumbnail')
       }),
-      key: state.get('id'),
       isBrowser: true,
       isRemote: true,
+      mozApp: url.isPrivileged(state.get('uri')) ? url.getManifestURL() : null,
       allowFullScreen: true,
 
       isVisible: isActive(state) ||
@@ -69,7 +70,7 @@ define((require, exports, module) => {
       onAuthentificate: WebViewer.onAuthentificate(edit),
       onScrollAreaChange: WebViewer.onScrollAreaChange(edit),
       onLoadProgressChange: WebViewer.onLoadProgressChange(edit)
-    })
+    });
   });
 
 


### PR DESCRIPTION
This comes with 2 commits:

* Support for `about:*` urls. `about:foobar` will load `http://…/src/about/foobar/index.html` in a privileged tab, which has the same privileges as browser.html.

* `about:settings` page. Just dump the settings. Very basic, but will be useful to check versions & co.