### PR TITLE
Reset readyState to fix repeated commands.

### DIFF
--- a/src/browser/web-viewer.js
+++ b/src/browser/web-viewer.js
@@ -161,6 +161,7 @@ define((require, exports, module) => {
   WebViewer.onLocationChange = edit => event => {
     edit(state => state.
                     merge({uri: event.detail,
+                           readyState: state.isLoading ? 'loading' : 'loaded',
                            userInput: event.detail}).
                     merge(getHardcodedColors(event.detail)));
 


### PR DESCRIPTION
Currently there are bunch of issues caused by `readyState` field not being reset, for example if you do refresh twice second one is ignored that's because `readyState` value will be `refresh` instead of `loaded`. Similar issues happen with `goBack` `goForward`.