### PR TITLE
Unite location and uri into single field.

### DIFF
--- a/src/browser/actions.js
+++ b/src/browser/actions.js
@@ -107,7 +107,7 @@ define((require, exports, module) => {
       set('runtimeUpdateAvailable', false).
       // Reset state of each web viewer that can't be carried across the sessions.
       updateIn(['webViewers'], viewers => viewers.map(viewer => viewer.merge({
-        uri: viewer.get('location') || viewer.get('uri'),
+        uri: viewer.get('uri'),
         thumbnail: null,
         location: null,
         readyState: null,

--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -15,12 +15,12 @@ define((require, exports, module) => {
     isBrowser: new BeforeAppendAttribute('mozbrowser'),
     mozApp: new BeforeAppendAttribute('mozapp'),
     allowFullScreen: new BeforeAppendAttribute('mozallowfullscreen'),
-    src: VirtualAttribute((node, current, past) => {
+    uri: VirtualAttribute((node, current, past) => {
       if (current != past) {
-        if (node.setVisible) {
-          node.src = current;
-        } else {
-          node.src = `data:text/html,${current}`
+        const uri = node.setVisible ? current : `data:text/html,${current}`
+        if (node.getAttribute("uri") !== uri) {
+          node.setAttribute("uri", uri);
+          node.src = uri;
         }
       }
     }),
@@ -75,7 +75,12 @@ define((require, exports, module) => {
     onUserActivityDone: Event('mozbrowseractivitydone'),
     onVisibilityChange: Event('mozbrowservisibilitychange'),
     onMetaChange: Event('mozbrowsermetachange'),
-    onLocationChange: Event('mozbrowserlocationchange'),
+    onLocationChange: VirtualEvent((target, dispatch) => {
+      target.addEventListener('mozbrowserlocationchange', event => {
+        target.setAttribute("uri", event.detail);
+        dispatch(event);
+      });
+    }),
     onSecurityChange: Event('mozbrowsersecuritychange'),
     onTitleChange: Event('mozbrowsertitlechange'),
     onPrompt: Event('mozbrowsershowmodalprompt'),

--- a/src/browser/navigation-panel.js
+++ b/src/browser/navigation-panel.js
@@ -127,13 +127,13 @@ define((require, exports, module) => {
         DOM.span({key: 'location',
                   style: theme.locationText,
                   className: 'pageurlsummary'},
-                 webViewer.get('location') ? getDomainName(webViewer.get('location')) : ''),
+                 webViewer.get('uri') ? getDomainName(webViewer.get('uri')) : ''),
         DOM.span({key: 'title',
                   className: 'pagetitle',
                   style: theme.titleText},
                  webViewer.get('title') ? webViewer.get('title') :
                  webViewer.get('isLoading') ? 'Loading...' :
-                 webViewer.get('location') ? webViewer.get('location') :
+                 webViewer.get('uri') ? webViewer.get('uri') :
                  'New Tab')
       ]),
       DOM.div({key: 'reload-button',
@@ -156,11 +156,11 @@ define((require, exports, module) => {
         navbar: true,
         urledit: input.get('isFocused'),
         cangoback: webViewer.get('canGoBack'),
-        canreload: webViewer.get('location'),
+        canreload: webViewer.get('uri'),
         loading: webViewer.get('isLoading'),
         ssl: webViewer.get('securityState') == 'secure',
         sslv: webViewer.get('securityExtendedValidation'),
-        privileged: isPrivileged(webViewer.get('location'))
+        privileged: isPrivileged(webViewer.get('uri'))
       })
     }, [
       WindowControls({key: 'WindowControls', isDocumentFocused, theme}),

--- a/src/browser/web-viewer.js
+++ b/src/browser/web-viewer.js
@@ -47,7 +47,7 @@ define((require, exports, module) => {
 
       zoom: state.get('zoom'),
       isFocused: state.get('isFocused'),
-      src: state.get('uri'),
+      uri: state.get('uri'),
       readyState: state.get('readyState'),
 
       onCanGoBackChange: WebViewer.onCanGoBackChange(edit),
@@ -135,7 +135,6 @@ define((require, exports, module) => {
     icons: {},
     thumbnail: null,
     title: null,
-    location: null,
     securityState: 'insecure',
     securityExtendedValidation: false,
     canGoBack: false,
@@ -161,7 +160,7 @@ define((require, exports, module) => {
 
   WebViewer.onLocationChange = edit => event => {
     edit(state => state.
-                    merge({location: event.detail,
+                    merge({uri: event.detail,
                            userInput: event.detail}).
                     merge(getHardcodedColors(event.detail)));
 

--- a/src/browser/web-viewer/actions.js
+++ b/src/browser/web-viewer/actions.js
@@ -34,11 +34,8 @@ define((require, exports, module) => {
     isSelected: false,
     // Text typed into the address bar.
     input: null,
-    // URI that web viewer was navigated to. Note that this does not
-    // represent uri that is currently loaded.
+    // URI that is loaded / loading in the web viewer.
     uri: null,
-    // Currently loaded `URI` in a web viewer.
-    location: null,
     // Currently loaded content's title.
     title: null,
     // Icons from the loaded web content.
@@ -90,7 +87,7 @@ define((require, exports, module) => {
     viewer.set('zoom', initial.get('zoom'));
 
   const title = viewer =>
-    viewer.get('title') || viewer.get('location') || viewer.get('uri');
+    viewer.get('title') || viewer.get('uri');
 
   // Exports:
 


### PR DESCRIPTION
This is related to discussion in #250 regarding a webview state simplification that drops `location` field in favor of `uri`.

This change basically moves hack from web view into iframe which is required to avoid changing a `iframe.src` if new value matches curretly loaded content `uri`. 