### PR TITLE
Basic integration test support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+graphene
 .DS_Store
 node_modules/
 .profile/

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ In the future, we want `browser.html` to be able to run on top of Servo.
 
 The easiest way to use developer tools with Browser.html is to select the "Remote Runtime" option in WebIDE.
 By default you should be able to connect to the running browser at: localhost:6000.
+
+
+### Integration Tests
+Run integration tests with `./test/runall.sh`. You need to have a graphene gecko binary symlinked in the root of the repository.
+
+```
+ln -s ../gecko/obj-graphene/dist/Graphene.app graphene
+```

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   ],
   "dependencies": {
     "immutable": "git://github.com/jcranendonk/immutable-js.git#0986651df9398187390f4638424adb532985439f",
+    "marionette-client": "^1.7.5",
+    "graphene-marionette-runner": "^0.0.5",
+    "mocha": "2.2.4",
     "node-uuid": "1.4.3",
     "omniscient": "3.1.0",
     "pouchdb": "3.5.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--ui tdd
+--timeout 600s
+--reporter spec

--- a/test/new_tab_test.js
+++ b/test/new_tab_test.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+
+marionette('new tab test', function() {
+  var client = marionette.client({
+    'browser.shell.checkDefaultBrowser': false
+  });
+
+  test('opens a new tab', function() {
+    var tiles = client.findElements('.tile-thumbnail');
+    assert.ok(tiles.length, 12);
+
+    var src = tiles[0].getAttribute('href');
+    tiles[0].tap();
+
+    client.waitFor(function() {
+      return client.findElement('iframe[src="https://facebook.com"]').displayed();
+    });
+  });
+});

--- a/test/runall.sh
+++ b/test/runall.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ve
+
+./node_modules/.bin/marionette-mocha \
+  --host-log stdout \
+  --host $(pwd)/node_modules/graphene-marionette-runner/host/index.js \
+  --runtime ./graphene/Contents/MacOS/graphene \
+  --start-manifest http://localhost:6060/manifest.webapp \
+  $(find test -name '*_test.js') $@;


### PR DESCRIPTION
This is using some forked b2g testing packages here: https://github.com/kevingrandon/graphene-marionette-runner

It's still a bit rough around the edges, but should give you an idea of how things could work. Next up would be importing the node http servers from gaia to serve static content from a fixtures directory.