### PR TITLE
Add backspace-to-go-back command

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -62,6 +62,7 @@ define((require, exports, module) => {
 
     'accel r': _ => WebView.Action.Navigation.Reload(),
     'escape': _ => WebView.Action.Navigation.Stop(),
+    'backspace': _ => WebView.Action.Navigation.GoBack(),
     [`${modifier} left`]: _ => WebView.Action.Navigation.GoBack(),
     [`${modifier} right`]: _ => WebView.Action.Navigation.GoForward()
   }, 'Browser.Keyboard.Action');

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -63,6 +63,7 @@ define((require, exports, module) => {
     'accel r': _ => WebView.Action.Navigation.Reload(),
     'escape': _ => WebView.Action.Navigation.Stop(),
     'backspace': _ => WebView.Action.Navigation.GoBack(),
+    'shift backspace': _ => WebView.Action.Navigation.GoForward(),
     [`${modifier} left`]: _ => WebView.Action.Navigation.GoBack(),
     [`${modifier} right`]: _ => WebView.Action.Navigation.GoForward()
   }, 'Browser.Keyboard.Action');


### PR DESCRIPTION
Hitting delete key will jump back to previous page in tab history.