### PR TITLE
Use CSS to animate progressbars

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -1,0 +1,10 @@
+@keyframes progressBarLoading {
+  from {
+    transform: translateX(-100vw);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-40vw);
+    opacity: 1;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta charset='utf-8'>
     <title>firefox</title>
     <link rel='stylesheet' title='default' href='css/theme.css'>
-    <link rel='stylesheet' title='default' href='css/tabstrip.css'>
+    <link rel='stylesheet' title='default' href='css/animations.css'>
 
 
     <!-- Module handling -->

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -133,19 +133,6 @@ define((require, exports, module) => {
   exports.update = update;
 
 
-  /*
-  exports.update = inspect(update, ([state, action], output) => {
-    if (action instanceof WebView.Action.Progress.LoadProgress) {
-      return null;
-    }
-
-    console.log(action.toString(),
-                state.toJSON(),
-                output && output.toJSON());
-  });
-  */
-
-
   // Style
 
   const style = StyleSheet.create({
@@ -167,8 +154,7 @@ define((require, exports, module) => {
 
   const view = (state, address) => {
     const {shell, webViews, input, suggestions} = state;
-    const {loader, page, progress, security} = WebView.get(webViews,
-                                                           webViews.selected);
+    const {loader, page, security} = WebView.get(webViews, webViews.selected);
 
     const theme = input.isFocused ? defaultTheme :
                   page ? cache(Theme.read, page.pallet) :
@@ -197,10 +183,6 @@ define((require, exports, module) => {
         shell,
         theme,
         address),
-      !input.isFocused && render('ProgressBar', Progress.view,
-        loader && loader.id,
-        progress,
-        theme, address),
       render('LocationBar', LocationBar.view,
         loader, security, page,
         input, suggestions, theme, address),
@@ -219,6 +201,11 @@ define((require, exports, module) => {
         address,
         webViews.selected,
         !input.isFocused),
+      render('ProgressBars', Progress.view,
+        webViews.loader,
+        webViews.progress,
+        webViews.selected,
+        theme),
       render('Updater', Updates.view, state.updates, address)
     ])
   };

--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -17,7 +17,6 @@ define((require, exports, module) => {
   const Navigation = require('./web-navigation');
   const Shell = require('./web-shell');
   const Input = require('./web-input');
-  const Progress = require('./progress-bar');
   const Suggestions = require('./suggestion-box');
   const ClassSet = require('common/class-set');
 
@@ -179,8 +178,6 @@ define((require, exports, module) => {
   const ReloadIcon = '\uf01e';
   const StopIcon = '\uf00d';
   const SEARCH_ICON = '\uf002';
-
-  const isLoading = Progress.isLoading;
 
   const Change = ({id}, {target}) =>
     Input.Action.Change({

--- a/src/browser/progress-bar.js
+++ b/src/browser/progress-bar.js
@@ -6,164 +6,125 @@ define((require, exports, module) => {
 
   'use strict';
 
-  const {html} = require('reflex');
-  const {animate} = require('common/animation');
   const {Record, Union} = require('common/typed');
-  const Theme = require('./theme');
   const {StyleSheet, Style} = require('common/style');
+  const {html, render} = require('reflex');
 
   // Model
-
   const Model = Record({
-    loadStarted: 0,
-    connected: 0,
-    loadEnded: 0,
-
-    value: 0
+    loadStarted: false,
+    loadEnded: false,
   });
   exports.Model = Model;
 
-  // Returns `true` if associated web-view is loading a page.
-  const isLoading = ({loadStarted, value}) =>
-    loadStarted > 0 && value < 1;
-  exports.isLoading = isLoading;
-
-  // Returns `true` if associated web-view connected to server.
-  const isConnecting = ({loadStarted, connected}) =>
-    loadStarted > 0 && connected <= 0;
-  exports.isConnecting = isConnecting;
-
-
-  // Actions
-
-  const LoadProgress = Record({
-    id: String,
-    timeStamp: Number
-  }, 'WebView.Progress.LoadProgress');
-
-  const ProgressChange = Record({
-    id: String,
-    value: Number
-  }, 'WebView.Progress.Change');
+  // Action
 
   const LoadStart = Record({
     id: String,
     uri: String,
-    timeStamp: Number
-  }, 'WebView.Progress.LoadStart');
+  }, 'Progress.LoadStart');
 
   const LoadEnd = Record({
     id: String,
     uri: String,
-    timeStamp: Number
-  }, 'WebView.Progress.LoadEnd');
+  }, 'Progress.LoadEnd');
 
-
-  exports.LoadProgress = LoadProgress;
-  exports.LoadStart = LoadStart;
-  exports.LoadEnd = LoadEnd;
-  exports.Action = Union({LoadProgress, ProgressChange, LoadStart, LoadEnd});
-
-
-  // Update
+  const Action = Union({LoadStart, LoadEnd});
+  exports.Action = Action;
 
   const update = (state, action) =>
-    !action ? state :
-    action instanceof LoadStart ? state.clear().set('loadStarted', action.timeStamp) :
-    action instanceof LoadEnd ? state.set('loadEnded', action.timeStamp) :
-    action instanceof ProgressChange ? state.clear().set('value', action.value) :
-    // Only update `connected` if web-view is connecting.
-    action instanceof LoadProgress ?
-      (isConnecting(state) ? state.set('connected', action.timeStamp) :
-      state.set('value', computeProgress({
-        now: action.timeStamp,
-        loadStarted: state.loadStarted,
-        connected: state.connected,
-        loadEnded: state.loadEnded
-      }))) :
+    action instanceof LoadStart ?
+      state.merge({loadStarted: true, loadEnded: false}) :
+    action instanceof LoadEnd ?
+      state.merge({loadEnded: true}) :
     state;
+
   exports.update = update;
-
-
-  // Animation parameters:
-  const A = 0.2;              // Zone A size (a full progress is equal to '1'
-  const B = 0.2;              // Zone B size
-  const APivot = 200;         // When to reach ~80% of zone A
-  const BPivot = 500;         // When to reach ~80% of zone B
-  const CDuration = 200;     // Time it takes to fill zone C
-  const Precision = 10000;
-
-  const approach = (tMs, pivoMs) => 2 * Math.atan(tMs / pivoMs) / Math.PI;
-
-
-   // Progress bar logic:
-   // The progressbar is split in 3 zones. Called A, B and C.
-   //   Zone A is slowly filled while the browser is connecting to the server.
-   //   Zone B is slowly filled while the page is being downloaded.
-   //   Zone C is filled once the page has loaded (fast).
-   //   Zone A and B get filled slower and slower in a way that they are never
-   //   100% filled.
-  const computeProgress = ({now, loadStarted, connected, loadEnded}) => {
-    // Inverse tangent function: [0 - inf] -> [0 - PI/2]
-    // approach: [time, pivot] -> [0 - 1]
-    // Pivot value is more or less when the animation seriously starts to slow down
-
-    const a = loadStarted <= 0 ? 0 :
-              A * approach(now - loadStarted, APivot);
-    const b = connected <= 0 ? 0 :
-              B * approach(now - connected, BPivot);
-    const c = loadEnded <= 0 ? 0 :
-              (1 - a - b) * (now - loadEnded) / CDuration;
-
-    const value = Math.min(1, a + b + c);
-
-    // Adjust a percision to avoid redundunt render cycles.
-    return Math.floor(Math.round(value * Precision)) / Precision;
-  };
-
-  // Style
-
-  const style = StyleSheet.create({
-    base: {
-      zIndex: 1,
-      display: 'block',
-      width: '100%',
-      height: 4,
-      marginLeft: '-100%',
-      position: 'absolute',
-      top: 28,
-      left: 0,
-      backgroundColor: null,
-      opacity: null,
-      transform: null
-    }
-  });
 
   // View
 
-  const startFading = 0.8;    // When does opacity starts decreasing to 0
-  const computeOpacity = progress =>
-    progress < startFading ? 1 :
-    1 - Math.pow((progress - startFading) / (1 - startFading), 1);
+  const barStyle = StyleSheet.create({
+    base: {
+      height: 4,
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      transitionProperty: 'transform, opacity',
+      transitionDuration: '300ms, 200ms',
+      transitionTimingFunction: 'ease-out',
+      transitionDelay: '0s, 300ms',
 
-  const ProgressUpdate = (id, {timeStamp}) =>
-    LoadProgress({id, timeStamp});
+      animationDuration: '10s',
+      animationTimingFunction: 'cubic-bezier(0, 0.5, 0, 0.5)',
 
-  const view = (id, progress, theme, address) => {
-    const node = progress && html.div({
-      key: 'ProgressBar',
-      style: Style(style.base, {
-        backgroundColor: theme.progressBar,
-        opacity: computeOpacity(progress.value),
-        transform: `translateX(${100 * progress.value}%)`
+      transform: 'translateX(-100vw)',
+      opacity: 0,
+    },
+    hidden: {
+      visibility: 'hidden'
+    },
+    visible: {
+      visibility: 'visible'
+    },
+    loading: {
+      animationName: 'progressBarLoading'
+    },
+    loaded: {
+      transform: 'translateX(0vw)',
+      opacity: 0
+    }
+  });
+
+  const arrowStyle = StyleSheet.create({
+    base: {
+      width: 4,
+      height: 4,
+      float: 'right',
+      marginRight: -4
+    }
+  });
+
+  const progressbarView = (id, progress, isSelected, theme) => {
+    return html.div({
+      key: `progressbar-${id}`,
+      style: Style(barStyle.base,
+                   !isSelected ? barStyle.hidden : barStyle.visible,
+                   progress.loadEnded ? barStyle.loaded : barStyle.loading, {
+                     backgroundColor: theme.progressBar
+                   }),
+    }, [html.div({
+      key: `progressbar-arrow-${id}`,
+      style: Style(arrowStyle.base, {
+        backgroundImage: `linear-gradient(135deg, ${theme.progressBar} 50%, transparent 50%)`,
       })
-    });
-
-    // If `webView` is loading then animate node with `ProgressChange` actions
-    // on every animatation frame.
-    return !progress ? null :
-           !isLoading(progress) ? node :
-           animate(node, address.pass(ProgressUpdate, id));
+    })]);
   };
+
+  const containerStyle = StyleSheet.create({
+    base: {
+      position: 'absolute',
+      top: 28,
+      left: 0,
+      width: '100vw',
+      height: 4,
+      overflow: 'hidden',
+      pointerEvents: 'none',
+    }
+  });
+
+  const view = (loaders, progress, selected, theme) => {
+    return html.div({
+      key: 'progressbars',
+      style: containerStyle.base
+    }, loaders.map((loader, index) =>
+      render(`progressbar@${loader.id}`, progressbarView,
+             loader.id,
+             progress.get(index),
+             index === selected,
+             theme)));
+  };
+
   exports.view = view;
+
 });

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -277,7 +277,6 @@ define((require, exports, module) => {
       onPrompt: action,
       onAuthentificate: action,
       onScrollAreaChange: action,
-      onLoadProgressChange: action
     });
   };
   exports.viewWebView = viewWebView;
@@ -396,16 +395,13 @@ define((require, exports, module) => {
     CanGoForwardChange({id, value});
 
 
-  const {LoadStart, LoadEnd, LoadProgress} = Progress.Action;
+  const {LoadStart, LoadEnd} = Progress.Action;
 
   Event.mozbrowserloadstart = ({id, uri}, {timeStamp}) =>
-    LoadStart({id, uri, timeStamp: performance.now()});
+    LoadStart({id, uri});
 
   Event.mozbrowserloadend = ({id, uri}, {timeStamp}) =>
-    LoadEnd({id, uri, timeStamp: performance.now()});
-
-  Event.mozbrowserloadprogresschanged = ({id}, {timeStamp}) =>
-    LoadProgress({id, timeStamp: performance.now()});
+    LoadEnd({id, uri});
 
   const {TitleChange, IconChange, MetaChange, OverflowChange, Scroll} = Page.Action;
 


### PR DESCRIPTION
Instead of having one single progressbar, here, I build one progressbar per webview. That allows us to keep the `translateX` position when switching tabs. With some transition and animation magics, we can reproduce the previous behavior.

The result is a much smoother animation.

Maybe the progresssbar should be built outside of the webview.

I'm wondering if passing the theme into the webview then to the progressbar is a problem (iirc, we had some issues because of that earlier).

I renamed Progress to WebProgress just to make my life easier when doing the rewrite. We can keep it that way or go back to Progress(bar).