### PR TITLE
Fix color themes

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -137,9 +137,9 @@ define((require, exports, module) => {
   const view = (state, address) => {
     const {shell, webViews, input, suggestions} = state;
     const {loader, page, security} = WebView.get(webViews, webViews.selected);
-	const id = loader && loader.id;
-    const theme = input.isFocused ? defaultTheme :
-                  page ? cache(Theme.read, page.pallet) :
+    const id = loader && loader.id;
+
+    const theme = page ? cache(Theme.read, page.pallet) :
                   defaultTheme;
 
     return Main({

--- a/src/browser/theme.js
+++ b/src/browser/theme.js
@@ -15,9 +15,6 @@ define((require, exports, module) => {
     isDark: false,
     glyphsShowing: false,
 
-    // reload, stop, back button color.
-    controlButton: Color('rgba(0,0,0,0.5)'),
-
     inputText: Color('rgba(0,0,0,0.65)'),
     locationText: Color('rgba(0,0,0, 0.65)'),
     titleText: Color('rgba(0,0,0,0.5)'),
@@ -36,8 +33,6 @@ define((require, exports, module) => {
     const background = pallet && pallet.background || void(0);
     return !pallet ? Model() : Model({
       isDark: pallet.isDark,
-
-      controlButton: foreground,
 
       inputText: foreground,
       locationText: foreground,

--- a/src/browser/theme.js
+++ b/src/browser/theme.js
@@ -18,10 +18,6 @@ define((require, exports, module) => {
     // reload, stop, back button color.
     controlButton: Color('rgba(0,0,0,0.5)'),
 
-    closeButton: Color('#FC5753'),
-    minButton: Color('#FDBC40'),
-    maxButton: Color('#33C748'),
-
     inputText: Color('rgba(0,0,0,0.65)'),
     locationText: Color('rgba(0,0,0, 0.65)'),
     titleText: Color('rgba(0,0,0,0.5)'),
@@ -40,10 +36,6 @@ define((require, exports, module) => {
     const background = pallet && pallet.background || void(0);
     return !pallet ? Model() : Model({
       isDark: pallet.isDark,
-
-      closeButton: foreground,
-      minButton: foreground,
-      maxButton: foreground,
 
       controlButton: foreground,
 

--- a/src/browser/theme.js
+++ b/src/browser/theme.js
@@ -13,7 +13,6 @@ define((require, exports, module) => {
 
   const Model = Record({
     isDark: false,
-    glyphsShowing: false,
 
     inputText: Color('rgba(0,0,0,0.65)'),
     locationText: Color('rgba(0,0,0, 0.65)'),

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -307,6 +307,8 @@ define((require, exports, module) => {
       updateByID(state, '@selected', action) :
     action instanceof Shell.ZoomOut ?
       updateByID(state, '@selected', action) :
+    action instanceof PalletChanged ?
+      updateByID(state, action.id, action) :
     action instanceof Action ?
       updateByID(state, action.id, action.action) :
     state;

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -308,8 +308,6 @@ define((require, exports, module) => {
       updateByID(state, '@selected', action) :
     action instanceof Shell.ZoomOut ?
       updateByID(state, '@selected', action) :
-    action instanceof PalletChanged ?
-      updateByID(state, action.id, action) :
     action instanceof Action ?
       updateByID(state, action.id, action.action) :
     state;

--- a/src/service/pallet.js
+++ b/src/service/pallet.js
@@ -69,7 +69,8 @@ define((require, exports, module) => {
 
   const PalletChanged = Record({
     id: String,
-    pallet: Model
+    pallet: Model,
+    description: 'Color pallet of page changed'
   }, 'Pallet.Action.Change');
   exports.PalletChanged = PalletChanged;
 

--- a/src/service/pallet.js
+++ b/src/service/pallet.js
@@ -68,7 +68,6 @@ define((require, exports, module) => {
   // Action
 
   const PalletChanged = Record({
-    id: String,
     pallet: Model,
     description: 'Color pallet of page changed'
   }, 'Pallet.Action.Change');
@@ -85,7 +84,10 @@ define((require, exports, module) => {
         // Use promise so behavior is going to be closer to what it will be
         // when we stop faking.
         Promise.resolve()
-               .then(address.send(PalletChanged({id: action.id, pallet})));
+          .then(address.send(WebView.Action({
+            id: action.id,
+            action: PalletChanged({pallet})
+          })));
       }
     }
     return action


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/467. Fix hardcoded color themes and themes generated using `theme-color`.

Will eventually follow up with a PR that bases themes on `background-color` instead of `theme-color` meta tag.