### PR TITLE
Tailor mode transitions (take 2)

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -52,7 +52,7 @@ define((require, exports, module) => {
   const modifier = OS.platform() == 'linux' ? 'alt' : 'accel';
   const KeyDown = KeyBindings({
     'accel l': _ => Input.Action({action: Focusable.Focus()}),
-    'accel t': _ => WebView.TransitionToOpenWithFade(),
+    'accel t': _ => WebView.FadeToOpen(),
     'accel 0': _ => Shell.ResetZoom(),
     'accel -': _ => Shell.ZoomOut(),
     'accel =': _ => Shell.ZoomIn(),

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -37,7 +37,7 @@ define((require, exports, module) => {
   const Model = Record({
     version: '0.0.7',
     mode: 'create-web-view', // or show-web-view, edit-web-view, choose-web-view
-    transition: 'normal', // or quick
+    transition: 'zoom', // or fade
     shell: Focusable.Model({isFocused: true}),
     updates: Updates.Model,
     webViews: WebView.Model,
@@ -51,14 +51,8 @@ define((require, exports, module) => {
 
   const modifier = OS.platform() == 'linux' ? 'alt' : 'accel';
   const KeyDown = KeyBindings({
-    'accel l': _ => Input.Action({
-      action: Focusable.Focus(),
-      source: 'keyboard'
-    }),
-    'accel t': _ => WebView.Action({
-      action: WebView.Open(),
-      source: 'keyboard'
-    }),
+    'accel l': _ => Input.Action({action: Focusable.Focus()}),
+    'accel t': _ => WebView.TransitionToOpenWithFade(),
     'accel 0': _ => Shell.ResetZoom(),
     'accel -': _ => Shell.ZoomOut(),
     'accel =': _ => Shell.ZoomIn(),

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -37,7 +37,7 @@ define((require, exports, module) => {
   const Model = Record({
     version: '0.0.7',
     mode: 'create-web-view', // or show-web-view, edit-web-view, choose-web-view
-    transition: 'zoom', // or fade
+    transition: 'zoom', // or fade, none
     shell: Focusable.Model({isFocused: true}),
     updates: Updates.Model,
     webViews: WebView.Model,

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -7,7 +7,7 @@ define((require, exports, module) => {
   'use strict';
 
   const {html, node, render, cache} = require('reflex');
-  const {Record, Any, Union} = require('common/typed');
+  const {Record, Any, Union, Maybe} = require('common/typed');
   const {inspect} = require('common/debug');
   const {StyleSheet, Style} = require('common/style');
   const WindowBar = require('./window-bar');
@@ -37,7 +37,7 @@ define((require, exports, module) => {
   const Model = Record({
     version: '0.0.7',
     mode: 'create-web-view', // or show-web-view, edit-web-view, choose-web-view
-    transition: 'zoom', // or fade, none
+    transition: Maybe(String), // zoom, fade, or null (no transition)
     shell: Focusable.Model({isFocused: true}),
     updates: Updates.Model,
     webViews: WebView.Model,

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -37,6 +37,7 @@ define((require, exports, module) => {
   const Model = Record({
     version: '0.0.7',
     mode: 'create-web-view', // or show-web-view, edit-web-view, choose-web-view
+    transition: 'normal', // or quick
     shell: Focusable.Model({isFocused: true}),
     updates: Updates.Model,
     webViews: WebView.Model,
@@ -50,8 +51,14 @@ define((require, exports, module) => {
 
   const modifier = OS.platform() == 'linux' ? 'alt' : 'accel';
   const KeyDown = KeyBindings({
-    'accel l': _ => Input.Action({action: Focusable.Focus()}),
-    'accel t': _ => WebView.Action({action: WebView.Open()}),
+    'accel l': _ => Input.Action({
+      action: Focusable.Focus(),
+      source: 'keyboard'
+    }),
+    'accel t': _ => WebView.Action({
+      action: WebView.Open(),
+      source: 'keyboard'
+    }),
     'accel 0': _ => Shell.ResetZoom(),
     'accel -': _ => Shell.ZoomOut(),
     'accel =': _ => Shell.ZoomIn(),
@@ -168,6 +175,7 @@ define((require, exports, module) => {
         state.mode, suggestions, input, theme, address),
       render('WebViews', WebView.view,
         state.mode,
+        state.transition,
         webViews.loader,
         webViews.shell,
         webViews.page,

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -58,7 +58,7 @@ define((require, exports, module) => {
     selectViewByID
   );
 
-  const showWebViewByIDFade = compose(
+  const fadeToWebViewByID = compose(
     fadeToShowMode,
     selectViewByID
   );
@@ -165,7 +165,7 @@ define((require, exports, module) => {
 
   const escape = state =>
     state.mode === 'show-web-view' ? state :
-    showWebViewByIDFade(state);
+    fadeToWebViewByID(state);
 
   const update = (state, action) =>
     action instanceof Navigation.Stop ?

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -103,7 +103,7 @@ define((require, exports, module) => {
     selectByOffset(-1));
 
   const closeWebViewByID = compose(
-    switchMode('edit-web-view', 'fade'),
+    switchMode('edit-web-view', 'none'),
     selectInput,
     focusInput,
     (state, id) =>

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -105,7 +105,7 @@ define((require, exports, module) => {
     selectByOffset(-1));
 
   const closeWebViewByID = compose(
-    switchMode('edit-web-view', 'none'),
+    switchMode('edit-web-view', null),
     selectInput,
     focusInput,
     (state, id) =>

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -143,7 +143,7 @@ define((require, exports, module) => {
       closeWebViewByID(state, id) :
     (action instanceof WebView.Open && !action.uri) ?
       createWebView(state, 'zoom') :
-    action instanceof WebView.TransitionToOpenWithFade ?
+    action instanceof WebView.FadeToOpen ?
       createWebView(state, 'fade') :
     action instanceof WebView.SelectNext ?
       selectNext(state) :
@@ -172,7 +172,7 @@ define((require, exports, module) => {
       updateByWebViewAction(state, action.id, action.action) :
     action instanceof WebView.Open ?
       updateByWebViewAction(state, null, action) :
-    action instanceof WebView.TransitionToOpenWithFade ?
+    action instanceof WebView.FadeToOpen ?
       updateByWebViewAction(state, null, action) :
     action instanceof WebView.Close ?
       updateByWebViewAction(state, null, action) :

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -135,15 +135,20 @@ define((require, exports, module) => {
 
 
   const updateByWebViewAction = (state, id, source, action) =>
-    action instanceof Focusable.Focus ? showWebViewByID(state, id) :
-    action instanceof Focusable.Focused ? showWebViewByID(state, id) :
-    action instanceof WebView.Close ? closeWebViewByID(state, id) :
+    action instanceof Focusable.Focus ?
+      showWebViewByID(state, id) :
+    action instanceof Focusable.Focused ?
+      showWebViewByID(state, id) :
+    action instanceof WebView.Close ?
+      closeWebViewByID(state, id) :
     (action instanceof WebView.Open && source === 'keyboard') ?
       createWebView(state, 'quick') :
     (action instanceof WebView.Open && !action.uri) ?
       createWebView(state, 'normal') :
-    action instanceof WebView.SelectNext ? selectNext(state) :
-    action instanceof WebView.SelectPrevious ? selectPrevious(state) :
+    action instanceof WebView.SelectNext ?
+      selectNext(state) :
+    action instanceof WebView.SelectPrevious ?
+      selectPrevious(state) :
     state;
 
   const updateByInputAction = (state, source, action) =>

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -50,12 +50,12 @@ define((require, exports, module) => {
     state.set('webViews', WebView.selectByID(state.webViews, id));
 
   const showWebViewByID = compose(
-    switchMode('show-web-view', 'normal'),
+    switchMode('show-web-view', 'zoom'),
     selectViewByID
   );
 
-  const showWebViewByIDQuick = compose(
-    switchMode('show-web-view', 'quick'),
+  const showWebViewByIDFade = compose(
+    switchMode('show-web-view', 'fade'),
     selectViewByID
   );
 
@@ -76,7 +76,7 @@ define((require, exports, module) => {
                        state.getIn(['webViews', 'loader', index, 'uri']));
   };
 
-  const editWebView = switchMode('edit-web-view', 'quick');
+  const editWebView = switchMode('edit-web-view', 'fade');
 
   const editWebViewByID = compose(
     state => state.mode === 'edit-web-view' ? state :
@@ -93,17 +93,17 @@ define((require, exports, module) => {
     state.set('webViews', WebView.selectByOffset(state.webViews, offset));
 
   const selectNext = compose(
-    switchMode('select-web-view', 'quick'),
+    switchMode('select-web-view', 'fade'),
     blurInput,
     selectByOffset(1));
 
   const selectPrevious = compose(
-    switchMode('select-web-view', 'quick'),
+    switchMode('select-web-view', 'fade'),
     blurInput,
     selectByOffset(-1));
 
   const closeWebViewByID = compose(
-    switchMode('edit-web-view', 'normal'),
+    switchMode('edit-web-view', 'fade'),
     selectInput,
     focusInput,
     (state, id) =>
@@ -121,7 +121,7 @@ define((require, exports, module) => {
   };
 
   const submit = compose(
-    switchMode('show-web-view', 'quick'),
+    switchMode('show-web-view', 'fade'),
     clearSuggestions,
     clearInput,
     navigate);
@@ -134,24 +134,24 @@ define((require, exports, module) => {
       setInputToURIByID(state, '@selected'));
 
 
-  const updateByWebViewAction = (state, id, source, action) =>
+  const updateByWebViewAction = (state, id, action) =>
     action instanceof Focusable.Focus ?
       showWebViewByID(state, id) :
     action instanceof Focusable.Focused ?
       showWebViewByID(state, id) :
     action instanceof WebView.Close ?
       closeWebViewByID(state, id) :
-    (action instanceof WebView.Open && source === 'keyboard') ?
-      createWebView(state, 'quick') :
     (action instanceof WebView.Open && !action.uri) ?
-      createWebView(state, 'normal') :
+      createWebView(state, 'zoom') :
+    action instanceof WebView.TransitionToOpenWithFade ?
+      createWebView(state, 'fade') :
     action instanceof WebView.SelectNext ?
       selectNext(state) :
     action instanceof WebView.SelectPrevious ?
       selectPrevious(state) :
     state;
 
-  const updateByInputAction = (state, source, action) =>
+  const updateByInputAction = (state, action) =>
     action instanceof Input.Submit ? submit(state, action.value) :
     action instanceof Focusable.Focus ? editWebViewByID(state, null) :
     action instanceof Focusable.Focused ? editWebViewByID(state, null) :
@@ -163,25 +163,27 @@ define((require, exports, module) => {
 
   const escape = state =>
     state.mode === 'show-web-view' ? state :
-    showWebViewByIDQuick(state);
+    showWebViewByIDFade(state);
 
   const update = (state, action) =>
     action instanceof Navigation.Stop ?
       escape(state) :
     action instanceof WebView.Action ?
-      updateByWebViewAction(state, action.id, action.source, action.action) :
+      updateByWebViewAction(state, action.id, action.action) :
     action instanceof WebView.Open ?
-      updateByWebViewAction(state, null, null, action) :
+      updateByWebViewAction(state, null, action) :
+    action instanceof WebView.TransitionToOpenWithFade ?
+      updateByWebViewAction(state, null, action) :
     action instanceof WebView.Close ?
-      updateByWebViewAction(state, null, null, action) :
+      updateByWebViewAction(state, null, action) :
     action instanceof WebView.SelectNext ?
-      updateByWebViewAction(state, null, null, action) :
+      updateByWebViewAction(state, null, action) :
     action instanceof WebView.SelectPrevious ?
-      updateByWebViewAction(state, null, null, action) :
+      updateByWebViewAction(state, null, action) :
     action instanceof Input.Action ?
-      updateByInputAction(state, action.source, action.action) :
+      updateByInputAction(state, action.action) :
     action instanceof Input.Submit ?
-      updateByInputAction(state, null, action) :
+      updateByInputAction(state, action) :
     action instanceof Gesture.Pinch ?
       showPreview(state) :
     action instanceof Select ?

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -35,6 +35,10 @@ define((require, exports, module) => {
   const switchMode = (mode, transition) => state =>
     state.merge({mode, transition});
 
+  const fadeToEditMode = switchMode('edit-web-view', 'fade');
+  const zoomToEditMode = switchMode('edit-web-view', 'zoom');
+  const fadeToSelectMode = switchMode('select-web-view', 'fade');
+  const fadeToShowMode = switchMode('show-web-view', 'fade');
 
   const edit = (field, update) =>
     state => state.update(field, update);
@@ -55,7 +59,7 @@ define((require, exports, module) => {
   );
 
   const showWebViewByIDFade = compose(
-    switchMode('show-web-view', 'fade'),
+    fadeToShowMode,
     selectViewByID
   );
 
@@ -76,12 +80,10 @@ define((require, exports, module) => {
                        state.getIn(['webViews', 'loader', index, 'uri']));
   };
 
-  const editWebView = switchMode('edit-web-view', 'fade');
-
   const editWebViewByID = compose(
     state => state.mode === 'edit-web-view' ? state :
              state.mode === 'create-web-view' ? state :
-             editWebView(state),
+             fadeToEditMode(state),
     selectInput,
     focusInput,
     (state, id) =>
@@ -93,12 +95,12 @@ define((require, exports, module) => {
     state.set('webViews', WebView.selectByOffset(state.webViews, offset));
 
   const selectNext = compose(
-    switchMode('select-web-view', 'fade'),
+    fadeToSelectMode,
     blurInput,
     selectByOffset(1));
 
   const selectPrevious = compose(
-    switchMode('select-web-view', 'fade'),
+    fadeToSelectMode,
     blurInput,
     selectByOffset(-1));
 
@@ -121,7 +123,7 @@ define((require, exports, module) => {
   };
 
   const submit = compose(
-    switchMode('show-web-view', 'fade'),
+    fadeToShowMode,
     clearSuggestions,
     clearInput,
     navigate);
@@ -129,7 +131,7 @@ define((require, exports, module) => {
   const showPreview = compose(
     state =>
       state.mode != 'show-web-view' ? state :
-      state.set('mode', 'edit-web-view'),
+      zoomToEditMode(state),
     state =>
       setInputToURIByID(state, '@selected'));
 
@@ -158,7 +160,7 @@ define((require, exports, module) => {
     state;
 
   const completeSelection = state =>
-    state.mode === 'select-web-view' ? state.set('mode', 'show-web-view') :
+    state.mode === 'select-web-view' ? fadeToShowMode(state) :
     state;
 
   const escape = state =>

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -275,7 +275,7 @@ define((require, exports, module) => {
     ]);
 
   const viewInEditMode = (loaders, pages, selected, theme, address) =>
-    viewContainer(theme, ...viewPreviews(loaders, pages, selected, address));
+    viewContainer(theme, ghostPreview, ...viewPreviews(loaders, pages, selected, address));
 
   const viewInCreateMode = (loaders, pages, selected, theme, address) =>
     // Pass selected as `-1` so none is highlighted.

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -44,7 +44,8 @@ define((require, exports, module) => {
 
   const DashboardIcon = '\uf067';
 
-  const OpenWebView = () => WebView.Action({action: WebView.Open()});
+  const OpenWebView = () =>
+    WebView.Action({action: WebView.Open()});
 
   const viewControls = (theme, address) => html.div({
     style: styleControls.panel

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -419,11 +419,16 @@ define((require, exports, module) => {
       transform: 'scale(0)',
       opacity: 0,
       pointerEvents: 'none',
+    },
+    hide: {
+      transform: 'scale(0)',
+      opacity: 0,
+      pointerEvents: 'none'
     }
   });
 
   // Given a mode and transition, returns appropriate style object.
-  const getModeStyle = (mode, transition) =>
+  const getModeStyle =  (mode, transition) =>
     (mode === 'show-web-view' && transition === 'fade') ?
       webviewsStyle.fadeIn :
     (mode === 'show-web-view' && transition === 'zoom') ?
@@ -432,8 +437,8 @@ define((require, exports, module) => {
       webviewsStyle.fadeOut :
     mode === 'select-web-view' ?
       webviewsStyle.fadeOut :
-    (mode === 'edit-web-view' && transition === 'none') ?
-      null :
+    (mode === 'edit-web-view' && !transition) ?
+      webviewsStyle.hide :
     (mode === 'edit-web-view' && transition === 'fade') ?
       webviewsStyle.fadeOut :
     webviewsStyle.shrink;

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -426,6 +426,8 @@ define((require, exports, module) => {
         webviewsStyle.grow :
       (mode === 'create-web-view' && transition === 'quick') ?
         webviewsStyle.fadeOut :
+      mode === 'select-web-view' ?
+        webviewsStyle.fadeOut :
       (mode === 'edit-web-view' && transition === 'quick') ?
         webviewsStyle.fadeOut :
       webviewsStyle.shrink;

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -83,10 +83,10 @@ define((require, exports, module) => {
   }, 'WebViews.Open');
   exports.Open = Open;
 
-  const TransitionToOpenWithFade = Record({
+  const FadeToOpen = Record({
     description: 'Transition to open-web-view mode with fade animation'
-  }, 'WebViews.TransitionToOpenWithFade');
-  exports.TransitionToOpenWithFade = TransitionToOpenWithFade;
+  }, 'WebViews.FadeToOpen');
+  exports.FadeToOpen = FadeToOpen;
 
   const OpenInBackground = Record({
     uri: String,

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -420,9 +420,13 @@ define((require, exports, module) => {
 
   const view = (mode, transition, loader, shell, page, address, selected) => {
     const additionalStyles =
-      mode === 'show-web-view' ?
+      (mode === 'show-web-view' && transition === 'quick') ?
+        webviewsStyle.fadeIn :
+      (mode === 'show-web-view' && transition === 'normal') ?
         webviewsStyle.grow :
       (mode === 'create-web-view' && transition === 'quick') ?
+        webviewsStyle.fadeOut :
+      (mode === 'edit-web-view' && transition === 'quick') ?
         webviewsStyle.fadeOut :
       webviewsStyle.shrink;
 

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -432,6 +432,8 @@ define((require, exports, module) => {
         webviewsStyle.fadeOut :
       mode === 'select-web-view' ?
         webviewsStyle.fadeOut :
+      (mode === 'edit-web-view' && transition === 'none') ?
+        null :
       (mode === 'edit-web-view' && transition === 'fade') ?
         webviewsStyle.fadeOut :
       webviewsStyle.shrink;

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -162,6 +162,7 @@ define((require, exports, module) => {
   // selected web-view.
   const Action = Record({
     id: Maybe(String),
+    source: Maybe(String),
     action: WebViewAction
   }, 'WebView.Action');
   exports.Action = Action;
@@ -393,23 +394,41 @@ define((require, exports, module) => {
       width: '100vw',
       height: 'calc(100vh - 28px)',
     },
-    active: {
-      transition: 'opacity 150ms linear',
+    fadeIn: {
+      transition: 'opacity 100ms linear',
+      transform: 'scale(1)',
+      opacity: 1,
     },
-    inactive: {
-      transition: 'transform 300ms linear, opacity 150ms linear',
+    fadeOut: {
+      transition: 'transform 0ms linear 100ms, opacity 100ms linear',
+      transform: 'scale(0)',
+      opacity: 0,
+      pointerEvents: 'none',
+    },
+    grow: {
+      transition: 'transform 200ms linear, opacity 200ms linear',
+      transform: 'scale(1)',
+      opacity: 1,
+    },
+    shrink: {
+      transition: 'transform 200ms linear, opacity 150ms linear',
       transform: 'scale(0)',
       opacity: 0,
       pointerEvents: 'none',
     }
   });
 
-  const view = (mode, loader, shell, page, address, selected) => {
-    const isActive = mode === 'show-web-view';
+  const view = (mode, transition, loader, shell, page, address, selected) => {
+    const additionalStyles =
+      mode === 'show-web-view' ?
+        webviewsStyle.grow :
+      (mode === 'create-web-view' && transition === 'quick') ?
+        webviewsStyle.fadeOut :
+      webviewsStyle.shrink;
+
     return html.div({
       key: 'web-views',
-      style: Style(webviewsStyle.base,
-                   isActive ? webviewsStyle.active : webviewsStyle.inactive),
+      style: Style(webviewsStyle.base, additionalStyles),
     }, loader.map((loader, index) =>
       render(`web-view@${loader.id}`, viewWebView,
              loader,

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -83,6 +83,11 @@ define((require, exports, module) => {
   }, 'WebViews.Open');
   exports.Open = Open;
 
+  const TransitionToOpenWithFade = Record({
+    description: 'Transition to open-web-view mode with fade animation'
+  }, 'WebViews.TransitionToOpenWithFade');
+  exports.TransitionToOpenWithFade = TransitionToOpenWithFade;
+
   const OpenInBackground = Record({
     uri: String,
     inBackground: true
@@ -162,7 +167,6 @@ define((require, exports, module) => {
   // selected web-view.
   const Action = Record({
     id: Maybe(String),
-    source: Maybe(String),
     action: WebViewAction
   }, 'WebView.Action');
   exports.Action = Action;
@@ -420,15 +424,15 @@ define((require, exports, module) => {
 
   const view = (mode, transition, loader, shell, page, address, selected) => {
     const additionalStyles =
-      (mode === 'show-web-view' && transition === 'quick') ?
+      (mode === 'show-web-view' && transition === 'fade') ?
         webviewsStyle.fadeIn :
-      (mode === 'show-web-view' && transition === 'normal') ?
+      (mode === 'show-web-view' && transition === 'zoom') ?
         webviewsStyle.grow :
-      (mode === 'create-web-view' && transition === 'quick') ?
+      (mode === 'create-web-view' && transition === 'fade') ?
         webviewsStyle.fadeOut :
       mode === 'select-web-view' ?
         webviewsStyle.fadeOut :
-      (mode === 'edit-web-view' && transition === 'quick') ?
+      (mode === 'edit-web-view' && transition === 'fade') ?
         webviewsStyle.fadeOut :
       webviewsStyle.shrink;
 

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -422,25 +422,26 @@ define((require, exports, module) => {
     }
   });
 
-  const view = (mode, transition, loader, shell, page, address, selected) => {
-    const additionalStyles =
-      (mode === 'show-web-view' && transition === 'fade') ?
-        webviewsStyle.fadeIn :
-      (mode === 'show-web-view' && transition === 'zoom') ?
-        webviewsStyle.grow :
-      (mode === 'create-web-view' && transition === 'fade') ?
-        webviewsStyle.fadeOut :
-      mode === 'select-web-view' ?
-        webviewsStyle.fadeOut :
-      (mode === 'edit-web-view' && transition === 'none') ?
-        null :
-      (mode === 'edit-web-view' && transition === 'fade') ?
-        webviewsStyle.fadeOut :
-      webviewsStyle.shrink;
+  // Given a mode and transition, returns appropriate style object.
+  const getModeStyle = (mode, transition) =>
+    (mode === 'show-web-view' && transition === 'fade') ?
+      webviewsStyle.fadeIn :
+    (mode === 'show-web-view' && transition === 'zoom') ?
+      webviewsStyle.grow :
+    (mode === 'create-web-view' && transition === 'fade') ?
+      webviewsStyle.fadeOut :
+    mode === 'select-web-view' ?
+      webviewsStyle.fadeOut :
+    (mode === 'edit-web-view' && transition === 'none') ?
+      null :
+    (mode === 'edit-web-view' && transition === 'fade') ?
+      webviewsStyle.fadeOut :
+    webviewsStyle.shrink;
 
-    return html.div({
+  const view = (mode, transition, loader, shell, page, address, selected) =>
+    html.div({
       key: 'web-views',
-      style: Style(webviewsStyle.base, additionalStyles),
+      style: Style(webviewsStyle.base, getModeStyle(mode, transition)),
     }, loader.map((loader, index) =>
       render(`web-view@${loader.id}`, viewWebView,
              loader,
@@ -448,7 +449,6 @@ define((require, exports, module) => {
              page.get(index).thumbnail,
              index === selected,
              address.forward(action => Action({id: loader.id, action})))));
-  };
   exports.view = view;
 
   // Actions that web-view produces but `update` does not handles.


### PR DESCRIPTION
Fix for https://github.com/mozilla/browser.html/issues/488.

In this version, we have a `mode` field and a `transition` field in the model.