### PR TITLE
make loader uri optional

### DIFF
--- a/src/browser/web-loader.js
+++ b/src/browser/web-loader.js
@@ -11,7 +11,7 @@ define((require, exports, module) => {
   // Model
   const Model = Record({
     id: String,
-    uri: String
+    uri: Maybe(String)
   }, 'WebLoader');
   exports.Model = Model;
 

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -256,7 +256,7 @@ define((require, exports, module) => {
     const loader = state.loader.get(index);
     return !loader ?
             open(state, action) :
-           URI.getOrigin(loader.uri) !== URI.getOrigin(action.uri) ?
+           loader.uri && (URI.getOrigin(loader.uri) !== URI.getOrigin(action.uri)) ?
             open(state, action) :
             updateByIndex(state, index, Loader.Load(action));
   };


### PR DESCRIPTION
It's an unnecessary constrain. If I want to open empty pages for example, this makes it impossible.