### PR TITLE
packaging

### DIFF
--- a/.bin/package.sh
+++ b/.bin/package.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+set -x #debug
+
+MINIFY=0
+
+TMPDIR=`mktemp -d 2>/dev/null || mktemp -d -t 'browserhtml'`
+
+rm -rf dist
+mkdir dist
+
+./node_modules/requirejs/bin/r.js -o ./build.js out=$TMPDIR/built.js
+
+if [ "$MINIFY" = 1 ] ; then
+  babel $TMPDIR/built.js > $TMPDIR/es5.js
+  uglifyjs --screw-ie8 $TMPDIR/es5.js > dist/main.js
+  rm $TMPDIR/es5.js
+  uglifyjs --screw-ie8 node_modules/requirejs/require.js > dist/require.js
+else
+  cp node_modules/requirejs/require.js dist/require.js
+  cp $TMPDIR/built.js dist/main.js
+fi
+
+
+mkdir dist/src
+cp -r css manifest.webapp net_error.html dist
+cp src/prerendering.js src/alexa.json dist/src
+cp index-dist.html dist/index.html
+
+rm $TMPDIR/built.js
+rmdir $TMPDIR

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ graphene
 .DS_Store
 node_modules/
 .profile/
+dist

--- a/build.js
+++ b/build.js
@@ -1,0 +1,32 @@
+({
+  baseUrl: 'node_modules/',
+  name: '../main',
+  optimize: 'none', // uglify doesn't work with ES6
+  paths: {
+    browser: '../src/browser',
+    browser2: '../src/browser2',
+    common: '../src/common',
+    lang: '../src/lang',
+    service: '../src/service',
+    // http://facebook.github.io/react/
+    react: 'react/dist/react.min',
+    // http://facebook.github.io/immutable-js/
+    // Because of the bug https://github.com/facebook/immutable-js/pull/297
+    // we use forked version until it's uplifted.
+    immutable: 'immutable/dist/immutable',
+    'typed-immutable': 'typed-immutable/lib/',
+    // https://github.com/broofa/node-uuid
+    uuid: 'node-uuid/uuid',
+    reflex: 'reflex/lib/index',
+    pouchdb: 'pouchdb/dist/pouchdb',
+    tinycolor: 'tinycolor2/tinycolor'
+  },
+  shim: {
+    tinycolor: {
+      exports: 'tinycolor'
+    },
+    pouchdb: {
+      exports: 'PouchDB'
+    }
+  }
+});

--- a/index-dist.html
+++ b/index-dist.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+  <!--
+
+      This Source Code Form is subject to the terms of the Mozilla Public
+      License, v. 2.0. If a copy of the MPL was not distributed with this
+      file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+  -->
+
+
+  <head>
+    <meta charset='utf-8'>
+    <title>firefox</title>
+    <link rel='stylesheet' title='default' href='css/theme.css'>
+
+    <!-- Module handling -->
+    <!-- All further JS code is loaded from javascript -->
+    <script data-main='./main' src='./require.js' defer></script>
+  </head>
+  <body tabindex="-1">
+    <script src='src/prerendering.js'></script>
+  </body>
+</html>
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "server": "ecstatic . --port 6060",
     "client": "/Applications/B2G.app/Contents/MacOS/graphene --profile ./.profile --start-manifest=http://localhost:6060/manifest.webapp",
     "start": "./.bin/start.js",
-    "deploy": "./.bin/deploy.sh"
+    "deploy": "./.bin/deploy.sh",
+    "package": "./.bin/package.sh"
   },
   "devDependencies": {
     "ecstatic": "^0.7.1",


### PR DESCRIPTION
This is the first step for packaging browser.html.

Running `npm run package` will creates a `dist` directory with the necessary files and concatenated scripts. Files are not minified yet (can't simply minify ES6 scripts).

For this script to work, this change is required for now:
```diff
diff --git a/src/service/history.js b/src/service/history.js
index 5cf07da..30e1dcf 100644
--- a/src/service/history.js
+++ b/src/service/history.js
@@ -34,7 +34,8 @@ define((require, exports, module) => {
   exports.PageQuery = PageQuery;

   const service = address => {
-    const worker = require('common/worker!service/history-worker');
+    return () => {};
+    // const worker = require('common/worker!service/history-worker');

     worker.onmessage = ({data: {type, action}}) => {
       if (type === 'PageResult') {
```