### PR TITLE
Fix session restore bug

### DIFF
--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -228,6 +228,7 @@ define((require, exports, module) => {
         isFocused: input.isFocused,
         selection: input.selection,
         onChange: inputAddress.pass(Change),
+        onSelect: inputAddress.pass(Change),
         onFocus: inputAddress.pass(Focusable.Focused),
         onBlur: inputAddress.pass(Focusable.Blured),
         onKeyDown: address.pass(Binding)


### PR DESCRIPTION
Fix for #486

So issue is related to selection state, which is set to `{start: 0, end: Infinity}` when we select all of the input. Although if such app state is stored it causes `JSON.serialize({start: 0, end: Infinity})` to run that produces `'{start:0, end:null}'` which is invalid state, given that `selection.end` is declared to be a number not a `null`.

Solution is to react to `selection` events and update state when the happen (please note that this was a case prior to refactoring, the fact that it is no longer a case was unintentional). Now with this change when we update selection by setting it to `{start: 0, end: Infinity}` that causes a `selection` event that will contain integer value for `selection.end` which is then stored into state, which in turn avoids an outlined bug caused by `JSON.serialize`.