### PR TITLE
Devtools shortcut

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -63,6 +63,10 @@
     'accel r': _ => Navigation.Reload(),
     'escape': _ => Navigation.Stop(),
     'F12': _ => DevtoolsHUD.ToggleDevtoolsHUD(),
+    // TODO: `meta alt i` generates `accel alt i` on OSX we need to look
+    // more closely into this but so declaring both shortcuts should do it.
+    'accel alt i': _ => DevtoolsHUD.ToggleDevtoolsHUD(),
+    'accel alt ˆ': _ => DevtoolsHUD.ToggleDevtoolsHUD(),
     [`${modifier} left`]: _ => Navigation.GoBack(),
     [`${modifier} right`]: _ => Navigation.GoForward()
   }, 'Browser.KeyDown.Action');

--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -170,16 +170,19 @@
   const StopIcon = '\uf00d';
   const SEARCH_ICON = '\uf002';
 
-  const Change = ({target}) =>
-    Editable.Change({
-      id: '@selected',
-      value: target.value,
-      selection: Editable.Selection({
-        start: target.selectionStart,
-        end: target.selectionEnd,
-        direction: target.selectionDirection
-      })
-    });
+  const readSelection = target => Editable.Selection({
+    start: target.selectionStart,
+    end: target.selectionEnd,
+    direction: target.selectionDirection
+  });
+
+  const Selected = ({target}) =>
+    Editable.Select({range: readSelection(target)});
+
+  const Changed = ({target}) => Editable.Change({
+    value: target.value,
+    selection: readSelection(target)
+  });
 
   const viewBar = mode => (address, children) => html.div({
     style: style.container,
@@ -224,8 +227,8 @@
         style: style.input,
         isFocused: input.isFocused,
         selection: input.selection,
-        onChange: inputAddress.pass(Change),
-        onSelect: inputAddress.pass(Change),
+        onChange: inputAddress.pass(Changed),
+        onSelect: inputAddress.pass(Selected),
         onFocus: inputAddress.pass(Focusable.Focused),
         onBlur: inputAddress.pass(Focusable.Blured),
         onKeyDown: address.pass(Binding)


### PR DESCRIPTION
`F12` is taken by OSX by default, there for I'm adding another keybinding that matches regular devtools key binding on all browsers.