### PR TITLE
Fix scraper to make it use promise properly.

### DIFF
--- a/src/service/scraper.js
+++ b/src/service/scraper.js
@@ -352,7 +352,7 @@
 
     // @TODO need some methods for scaling and cropping images.
 
-    const ready = new Promise((resolve) => {
+    const ready = new window.Promise((resolve) => {
       if (document.readyState === "complete") {
         resolve();
       } else {


### PR DESCRIPTION
Babel replaces all uses of `Promise` to `require('babel-core/runtime').Promise` that is either native promise or polyfill. This introduced a regression as we use `scraper` function with `Promise(...)` as `iframe.executeScript(scraper + '()')` which now breaks as `Promise` there will be replaced with `require('babel-core/runtime').Promise` and in the context it's run there is no `require`. Fix simply changes use to `window.Promise` so babel won't replace it and there for we won't run into this issue.