### PR TITLE
Keep the color pallet across domains.

### DIFF
--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -47,6 +47,8 @@
     onUserActivityDone: Event('mozbrowseractivitydone'),
     onVisibilityChanged: Event('mozbrowservisibilitychange'),
     onMetaChanged: Event('mozbrowsermetachange'),
+    onFirstPaint: Event('mozbrowserfirstpaint'),
+    onDocumentFirstPaint: Event('mozbrowserdocumentfirstpaint'),
     // Use `VirtualEvent` to proxy events in order to mutate `target.location`
     // so that user can check `target.location` before deciding if change to
     // `target.src` is required.

--- a/src/browser/web-page.js
+++ b/src/browser/web-page.js
@@ -9,6 +9,7 @@
   const Progress = require('./web-progress');
   const WebView = require('./web-view');
   const Favicon = require('../common/favicon');
+  const URI = require('../common/url-helper');
 
   // Model
 
@@ -22,6 +23,7 @@
   });
 
   const Model = Record({
+    uri: Maybe(String),
     title: Maybe(String),
 
     label: Maybe(String),
@@ -120,6 +122,13 @@
     return state.set('icon', bestIcon).set('faviconURL', faviconURL);
   }
 
+  const updateLocation = (state, {uri}) =>
+    !state.uri ? state.set('uri', uri) :
+    state.uri === uri ? state :
+    URI.getOrigin(state.uri) === URI.getOrigin(uri) ?
+      Model({uri, pallet: state.pallet, palletSource: 'inherit'}) :
+    Model({uri});
+
   const update = (state, action) =>
     action instanceof TitleChanged ? state.set('title', action.title) :
     action instanceof IconChanged ? updateIcon(state, action.icon) :
@@ -131,7 +140,7 @@
       palletSource: 'curated-theme-colors'
     }) :
     action instanceof PageCardChanged ? updateCard(state, action) :
-    action instanceof Progress.LoadStarted ? state.clear() :
+    action instanceof Loader.LocationChanged ? updateLocation(state, action) :
     state;
 
   exports.update = update;

--- a/src/browser/web-page.js
+++ b/src/browser/web-page.js
@@ -23,7 +23,6 @@
   });
 
   const Model = Record({
-    uri: Maybe(String),
     title: Maybe(String),
 
     label: Maybe(String),
@@ -122,12 +121,9 @@
     return state.set('icon', bestIcon).set('faviconURL', faviconURL);
   }
 
-  const updateLocation = (state, {uri}) =>
-    !state.uri ? state.set('uri', uri) :
-    state.uri === uri ? state :
-    URI.getOrigin(state.uri) === URI.getOrigin(uri) ?
-      Model({uri, pallet: state.pallet, palletSource: 'inherit'}) :
-    Model({uri});
+  const ensurePallet = state =>
+    state.palletSource ? state :
+    state.remove('pallet');
 
   const update = (state, action) =>
     action instanceof TitleChanged ? state.set('title', action.title) :
@@ -140,7 +136,9 @@
       palletSource: 'curated-theme-colors'
     }) :
     action instanceof PageCardChanged ? updateCard(state, action) :
-    action instanceof Loader.LocationChanged ? updateLocation(state, action) :
+    action instanceof Progress.LoadStarted ? state.remove('palletSource') :
+    action instanceof Progress.LoadEnded ? ensurePallet(state) :
+    action instanceof Loader.LocationChanged ? Model({pallet: state.pallet}) :
     state;
 
   exports.update = update;

--- a/src/browser/web-page.js
+++ b/src/browser/web-page.js
@@ -34,12 +34,24 @@
 
     thumbnail: Maybe(String),
     overflow: false,
-    palletSource: Maybe(String),
+
+    themeColor: Maybe(String),
+    curatedColor: Maybe(String),
     pallet: Pallet.Model
   });
   exports.Model = Model;
 
   // Action
+
+  const DocumentFirstPaint = Record({
+    description: 'Fired on a first page document paint'
+  }, 'WebView.DocumentFirstPaint');
+  exports.DocumentFirstPaint = DocumentFirstPaint;
+
+  const FirstPaint = Record({
+    description: 'Fired on a first paint'
+  }, 'WebView.FirstPaint');
+  exports.FirstPaint = FirstPaint;
 
   const MetaChanged = Record({
     description: 'Metadata of the page changed',
@@ -89,24 +101,19 @@
   }, 'WebView.Page.CardChange');
   exports.PageCardChanged = PageCardChanged;
 
+  const AnnounceCuratedColor = Pallet.AnnounceCuratedColor;
+  exports.AnnounceCuratedColor = AnnounceCuratedColor;
 
-  const {PalletChanged} = Pallet;
-  exports.PalletChanged = PalletChanged;
 
   // Update
 
-  const updateMeta = (state, action) => {
-    if (action.name === 'theme-color') {
-      // Never override pallet if there was a currated theme.
-      if (state.palletSource !== 'curated-theme-colors') {
-        return state.merge({
-          palletSource: 'theme-color',
-          pallet: Pallet.read(action.content)
-        });
-      }
-    }
-    return state
-  };
+  const updateMeta = (state, action) =>
+    state.curatedColor ? state :
+    action.name === 'theme-color' ? state.set('themeColor', action.content) :
+    state;
+
+  const updateTheme = (state, action) =>
+    state.set('curatedColor', action.color);
 
   const updateCard = (state, action) =>
     state.merge({
@@ -119,10 +126,11 @@
   const updateIcon = (state, icon) => {
     const {bestIcon, faviconURL} = Favicon.getBestIcon([state.icon, icon]);
     return state.set('icon', bestIcon).set('faviconURL', faviconURL);
-  }
+  };
 
-  const ensurePallet = state =>
-    state.palletSource ? state :
+  const updatePallet = state =>
+    state.curatedColor ? state.set('pallet', Pallet.read(state.curatedColor)) :
+    state.themeColor ? state.set('pallet', Pallet.read(state.themeColor)) :
     state.remove('pallet');
 
   const update = (state, action) =>
@@ -131,14 +139,11 @@
     action instanceof OverflowChanged && !state.overflow ? state.set('overflow', action.overflow) : // we don't want overflow to be set back to false
     action instanceof ThumbnailChanged ? state.set('thumbnail', action.image) :
     action instanceof MetaChanged ? updateMeta(state, action) :
-    action instanceof PalletChanged ? state.merge({
-      pallet: action.pallet,
-      palletSource: 'curated-theme-colors'
-    }) :
-    action instanceof PageCardChanged ? updateCard(state, action) :
-    action instanceof Progress.LoadStarted ? state.remove('palletSource') :
-    action instanceof Progress.LoadEnded ? ensurePallet(state) :
-    action instanceof Loader.LocationChanged ? Model({pallet: state.pallet}) :
+    action instanceof AnnounceCuratedColor ? updateTheme(state, action) :
+    action instanceof Progress.LoadStarted ? Model({pallet: state.pallet}) :
+    action instanceof DocumentFirstPaint ? updatePallet(state) :
+    // If you goBack `DocumentFirstPaint` does not seem to fire there for
+    // we updatePallet again on LoadEnded to cover that as well.
+    action instanceof Progress.LoadEnded ? updatePallet(state) :
     state;
-
   exports.update = update;

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -130,7 +130,8 @@
   const {LoadStarted, LoadEnded} = Progress;
   const {MetaChanged, ThumbnailChanged, TitleChanged,
          IconChanged, Scrolled, OverflowChanged,
-         PageCardChanged, PalletChanged} = Page;
+         FirstPaint, DocumentFirstPaint,
+         AnnounceCuratedColor, PageCardChanged} = Page;
   const {SecurityChanged} = Security;
   const {VisibilityChanged} = Shell;
   const {Focus, Blur, Focused, Blured} = Focusable;
@@ -148,7 +149,8 @@
     CanGoBackChanged, CanGoForwardChanged,
     // Page
     MetaChanged, ThumbnailChanged, TitleChanged, IconChanged, Scrolled,
-    OverflowChanged, PageCardChanged, PalletChanged,
+    OverflowChanged, PageCardChanged, FirstPaint, DocumentFirstPaint,
+    PageCardChanged, AnnounceCuratedColor,
     // Security
     SecurityChanged,
     // Shell
@@ -378,6 +380,8 @@
       onError: action,
       onLoadStarted: action,
       onLoadEnded: action,
+      onFirstPaint: action,
+      onDocumentFirstPaint: action,
       onLoadProgressChange: action,
       onLocationChanged: action,
       onMetaChanged: action,
@@ -462,6 +466,12 @@
 
   const Event = event =>
     Event[event.type](event);
+
+  Event.mozbrowserdocumentfirstpaint = event =>
+    DocumentFirstPaint();
+
+  Event.mozbrowserfirstpaint = event =>
+    FirstPaint();
 
   Event.mozbrowserlocationchange = ({detail: uri}) =>
     LocationChanged({uri});

--- a/src/service/pallet.js
+++ b/src/service/pallet.js
@@ -9,24 +9,22 @@
   const Loader = require('../browser/web-loader');
   const tinycolor = require('tinycolor2');
 
-  const DARK = true;
-
   const curated = {
-    // [foreground, background]
-    'facebook.com': ['#fff', '#3A5795'],
-    'sina.com.cn': ['#fff', '#ff8500', DARK],
-    'reddit.com': ['#336699', '#F0F0F0'],
-    'instagram.com': ['#fff', '#125688', DARK],
-    'imgur.com': ['#fff', '#2b2b2b', DARK],
-    'cnn.com': ['#fff', '#0c0c0c', DARK],
-    'slideshare.net': ['#fff', '#313131', DARK],
-    'deviantart.com': ['#fff', '#475c4d', DARK],
-    'soundcloud.com': ['#FF5500', '#333333', DARK],
-    'mashable.com': ['#fff', '#00aeef', DARK],
-    'daringfireball.net': ['#fff', '#4a525a', DARK],
-    'firewatchgame.com': ['#EF4338', '#2D102B', DARK],
-    'whatliesbelow.com': ['#fff', '#74888B', DARK],
-    'supertimeforce.com': ['#2EBCEC', '#051224', DARK]
+    // [background, foreground]
+    'facebook.com': ['#3a5795', '#fff'],
+    'sina.com.cn': ['#ff8500', '#fff'],
+    'reddit.com': ['#f0f0f0', '#336699'],
+    'instagram.com': ['#125688', '#fff'],
+    'imgur.com': ['#2b2b2b', '#fff'],
+    'cnn.com': ['#0c0c0c', '#fff'],
+    'slideshare.net': ['#313131', '#fff'],
+    'deviantart.com': ['#475c4d', '#fff'],
+    'soundcloud.com': ['#333333', '#FF5500'],
+    'mashable.com': ['#00aeef', '#fff'],
+    'daringfireball.net': ['#4a525a', '#fff'],
+    'firewatchgame.com': ['#2d102b', '#ef4338'],
+    'whatliesbelow.com': ['#74888b', '#fff', ],
+    'supertimeforce.com': ['#051224', '#2ebcec']
   };
 
   const Color = String;
@@ -59,11 +57,11 @@
 
   // Action
 
-  const PalletChanged = Record({
-    pallet: Model,
-    description: 'Color pallet of page changed'
-  }, 'Pallet.Action.Change');
-  exports.PalletChanged = PalletChanged;
+  const AnnounceCuratedColor = Record({
+    description: 'Announce theme colors for curated domains',
+    color: String
+  });
+  exports.AnnounceCuratedColor = AnnounceCuratedColor;
 
   const service = address => action => {
     if (action instanceof WebView.Action &&
@@ -71,15 +69,10 @@
       const hostname = URI.getDomainName(action.action.uri);
       const theme = curated[hostname];
       if (theme) {
-        const [foreground, background, isDark] = theme;
-        const pallet = Model({foreground, background, isDark});
-        // Use promise so behavior is going to be closer to what it will be
-        // when we stop faking.
-        Promise.resolve()
-          .then(address.send(WebView.Action({
-            id: action.id,
-            action: PalletChanged({pallet})
-          })));
+        address.receive(WebView.Action({
+          id: action.id,
+          action: AnnounceCuratedColor({color: theme.join('|')})
+        }));
       }
     }
     return action


### PR DESCRIPTION
This is imperfect fix for #536 that resets state of the page card only on location change if the location has changed, but keeps the color pallet unless domain has changed.