### PR TITLE
Shameful fix for #475 that makes me feel guilty.

### DIFF
--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -68,15 +68,27 @@
     }),
     isVisible: VirtualAttribute((node, current, past) => {
       if (current != past) {
-        if (node.setVisible && !node.isSetVisibleBroken) {
-          node.setVisible(current);
+        if (node.setVisible) {
+          try {
+            node.setVisible(current);
+          } catch (error) {
+            if (!node.isSetVisibleBroken) {
+              throw(error);
+            }
+          }
         }
       }
     }),
     zoom: VirtualAttribute((node, current, past) => {
       if (current != past) {
-        if (node.zoom && !node.isZoomBroken) {
-          node.zoom(current);
+        if (node.zoom) {
+          try {
+            node.zoom(current);
+          } catch (error) {
+            if (!node.isZoomBroken) {
+              throw(error);
+            }
+          }
         }
       }
     }),

--- a/src/browser/iframe.js
+++ b/src/browser/iframe.js
@@ -8,21 +8,6 @@
   const React = require('react');
   const {html} = require('reflex');
 
-  /*
-  const DOMProperty = require('react/lib/ReactInjection').DOMProperty;
-
-  // Configure react to make it understand custom mozbrowser attributes.
-  DOMProperty.injectDOMPropertyConfig({
-    Properties: {
-      'remote': DOMProperty.MUST_USE_ATTRIBUTE,
-      'mozbrowser': DOMProperty.MUST_USE_ATTRIBUTE,
-      'mozapp': DOMProperty.MUST_USE_ATTRIBUTE,
-      'mozallowfullscreen': DOMProperty.MUST_USE_ATTRIBUTE,
-    }
-  });
-  */
-
-
   class IFrameView extends ElementView {
     componentDidMount() {
       super.componentDidMount();

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -18,6 +18,7 @@
   const Scraper = require('../service/scraper');
   const Navigation = require('../service/navigation');
   const Gesture = require('../service/gesture');
+  const Force = require('../service/force');
 
   // Set up a address (message bus if you like) that will be used
   // as an address for all application components / services. This
@@ -25,6 +26,16 @@
   // application component for it handle it.
   const address = new Address({
     receive(action) {
+      // This is unfortunate hack to workaround gecko issues: #566, #565, #564
+      // Basic idea is that actions that need to happen in the same tick are
+      // boxed with `Force({action})`. Such actions are unboxed and render
+      // is forced at the end of the receive. This is likey to introduce some
+      // race conditions but for now that's the best we can do.
+      const isForced = action instanceof Force.Action;
+      if (isForced) {
+        action = action.action;
+      }
+
       application.receive(action);
       thumbnail(action);
       pallet(action);
@@ -34,6 +45,13 @@
       settings(action);
       scraper(action);
       navigation(action);
+
+      // We cancel scheduled render on next animation frame as we are
+      // forceing render to happen right away.
+      if (isForced) {
+        cancelAnimationFrame(application.version);
+        application.render();
+      }
     }
   });
   window.address = address;

--- a/src/browser/web-loader.js
+++ b/src/browser/web-loader.js
@@ -8,6 +8,7 @@
   // Model
   const Model = Record({
     id: String,
+    opener: Any,
     uri: Maybe(String)
   }, 'WebLoader');
   exports.Model = Model;

--- a/src/service/force.js
+++ b/src/service/force.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
+
+const {Record, Any} = require('../common/typed');
+
+const Action = Record({
+  description: 'Wrapped action will force immediate render',
+  action: Any
+});
+
+exports.Action = Action;


### PR DESCRIPTION
This is very hacky fix that has to workaround ton of issues, here is little overview:

- Workaround #566 and present desired API by boxing frame in a string instance that is later unboxed by an IFrame react component.
- Workaround #567 by setting a flag on iframe so that implementation of `IFrame` won't call `zoom` on it.
- Workaround #568  by setting a flag on iframe so that implementation of `IFrame` won't call `setVisible` on it. 
- Workaround #564 by creating a type `Force.Action` so that actions boxed with it will force render loop to run sync in the same tick.