### PR TITLE
Show title in card header

### DIFF
--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -130,7 +130,7 @@
     description: {
       fontSize: '12px',
       lineHeight: '18px',
-      height: '72px',
+      height: '90px',
       margin: '0px 10px',
       overflow: 'hidden',
       whiteSpace: 'normal'

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -91,17 +91,6 @@
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap'
     },
-    title: {
-      display: 'block',
-      fontSize: '14px',
-      fontWeight: 'bold',
-      lineHeight: '18px',
-      margin: '0 10px 8px 10px',
-      width: '200px',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap'
-    },
     icon: {
       backgroundSize: 'cover',
       backgroundPosition: 'center center',
@@ -148,14 +137,14 @@
     }
   });
 
-  const viewContentsHeroTitleDescription = (name, icon, hero, title, description, theme) => [
+  const viewContentsHeroTitleDescription = (title, icon, hero, description, theme) => [
     html.header({
         key: 'header',
         style: Style(stylePreview.header, {
           backgroundColor: theme.shell,
           color: theme.shellText
         }),
-      }, name),
+      }, title),
     html.span({
       key: 'icon',
       alt: '',
@@ -176,24 +165,20 @@
         onLoad: event => URL.revokeObjectURL(event.target.src)
       })
     ]),
-    html.div({
-      key: 'title',
-      style: stylePreview.title
-    }, title),
     html.p({
       key: 'description',
       style: stylePreview.description
     }, description)
   ];
 
-  const viewContentsScreenshot = (name, icon, screenshot, theme) => [
+  const viewContentsScreenshot = (title, icon, screenshot, theme) => [
     html.header({
         key: 'header',
         style: Style(stylePreview.header, {
           backgroundColor: theme.shell,
           color: theme.shellText
         }),
-      }, name),
+      }, title),
     html.span({
       key: 'icon',
       alt: '',
@@ -225,8 +210,8 @@
 
     const previewContents =
       hero && title && page.description ?
-        viewContentsHeroTitleDescription(name, icon, hero, title, page.description, theme) :
-        viewContentsScreenshot(name, icon, page.thumbnail, theme);
+        viewContentsHeroTitleDescription(title, icon, hero, page.description, theme) :
+        viewContentsScreenshot(title, icon, page.thumbnail, theme);
 
     return html.div({
       className: 'card',


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/578.

We should re-introduce the card title in card contents if we can get the
scraper to return good results for content headings.

@paulrouget r?