### PR TITLE
Reconcile edit/create states

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -25,6 +25,14 @@
   visibility: visible;
 }
 
+.card {
+  transition: transform 80ms linear;
+}
+
+.card:hover {
+  transform: scale(1.05);
+}
+
 * {
   -moz-appearance: none;
   background-color: transparent;

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -179,7 +179,7 @@
       render('LocationBar', LocationBar.view,
         state.mode, loader, security, page, input, suggestions, address),
       render('Preview', Preview.view,
-        state.mode, webViews.loader, webViews.page, webViews.previewed, theme, address),
+        state.mode, webViews.loader, webViews.page, input.isFocused, webViews.previewed, theme, address),
       render('Suggestions', Suggestions.view,
         state.mode, suggestions, input, address),
       html.div({

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -179,7 +179,7 @@
       render('LocationBar', LocationBar.view,
         state.mode, loader, security, page, input, suggestions, address),
       render('Preview', Preview.view,
-        state.mode, webViews.loader, webViews.page, input.isFocused, webViews.previewed, theme, address),
+        state.mode, webViews.loader, webViews.page, input.isFocused, webViews.previewed, address),
       render('Suggestions', Suggestions.view,
         state.mode, suggestions, input, address),
       html.div({

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -179,7 +179,7 @@
       render('LocationBar', LocationBar.view,
         state.mode, loader, security, page, input, suggestions, address),
       render('Preview', Preview.view,
-        state.mode, webViews.loader, webViews.page, input.isFocused, webViews.previewed, address),
+        state.mode, webViews.loader, webViews.page, input.isFocused, webViews.previewed, theme, address),
       render('Suggestions', Suggestions.view,
         state.mode, suggestions, input, address),
       html.div({

--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -60,8 +60,8 @@
     },
     // Display styles when location bar is displaying suggested result.
     suggesting: {
-      backgroundColor: 'white',
-      color: 'rgba(0,0,0,0.7)',
+      backgroundColor: 'rgba(0,0,0,0.07)',
+      color: 'rgba(0,0,0,0.65)',
       height: 30,
       lineHeight: '30px',
       padding: '0 30px',

--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -203,11 +203,11 @@
 
   const InputAction = action => Input.Action({action});
 
-  const viewInDashboard = (loader, security, page, input, suggestions, address) => {
+  const viewInDashboard = (mode, loader, security, page, input, suggestions, address) => {
     // Make forwarding addres that wraps actions into `Input.Action`.
     const inputAddress = address.forward(InputAction);
 
-    const view = Suggestions.isSuggesting(input, suggestions) ?
+    const view = Suggestions.isSuggesting(mode, input, suggestions) ?
       viewSuggestingBar : viewActiveBar;
 
     return view(inputAddress, [
@@ -277,7 +277,7 @@
 
   const view = (mode, ...rest) =>
     mode === 'show-web-view' ? viewInWebView(...rest) :
-    viewInDashboard(...rest);
+    viewInDashboard(mode, ...rest);
 
   // TODO: Consider seperating location input field from the location bar.
 

--- a/src/browser/location-bar.js
+++ b/src/browser/location-bar.js
@@ -55,7 +55,7 @@
       height: 30,
       lineHeight: '30px',
       padding: '0 30px',
-      width: 400,
+      width: 460,
       top: 40,
     },
     // Display styles when location bar is displaying suggested result.
@@ -65,7 +65,7 @@
       height: 30,
       lineHeight: '30px',
       padding: '0 30px',
-      width: 400,
+      width: 460,
       top: 40
     },
     button: {

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -162,7 +162,8 @@
       borderTop: 0
     },
     suggestion: {
-      lineHeight: '30px',
+      borderRadius: '4px',
+      lineHeight: '40px',
       paddingLeft: 10,
       paddingRight: 10,
       verticalAlign: 'middle',

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -254,15 +254,15 @@
   exports.viewSuggestion = viewSuggestion;
 
   // Check if input is in "suggestions" mode.
-  const isSuggesting = (input, suggestions) =>
-    input.isFocused && input.value && suggestions.entries.count() > 0;
+  const isSuggesting = (mode, input, suggestions) =>
+    mode === 'edit-web-view' || (input.isFocused && input.value);
   exports.isSuggesting = isSuggesting;
 
   const view = (mode, state, input, address) =>
     html.menu({
       key: 'suggestionscontainer',
       style: Style(style.container,
-                   !isSuggesting(input, state) && style.collapsed)
+                   !isSuggesting(mode, input, state) && style.collapsed)
     }, [
       html.ul({
         key: 'suggestions',

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -255,7 +255,8 @@
 
   // Check if input is in "suggestions" mode.
   const isSuggesting = (mode, input, suggestions) =>
-    mode === 'edit-web-view' || (input.isFocused && input.value);
+    (mode === 'edit-web-view' ||
+      (mode === 'create-web-view' && input.isFocused && input.value));
   exports.isSuggesting = isSuggesting;
 
   const view = (mode, state, input, address) =>

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -139,28 +139,23 @@
 
   const style = StyleSheet.create({
     container: {
-      textAlign: 'center',
+      backgroundColor: '#fff',
       width: '100vw',
       position: 'absolute',
-      top: 40,
+      top: 0,
       zIndex: 43,
-      height: 260,
+      height: '100vh',
+      left: 0,
       pointerEvents: 'none'
     },
     collapsed: {
       display: 'none'
     },
     suggestions: {
-      boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
       color: 'rgba(0,0,0,0.7)',
-      display: 'inline-block',
-      textAlign: 'left',
-      width: 400,
-      overflow: 'hidden',
-      pointerEvents: 'all',
-      backgroundColor: '#fff',
-      borderRadius: 5,
-      padding: '30px 0 5px'
+      width: 460,
+      margin: '260px auto 0',
+      pointerEvents: 'all'
     },
     first: {
       borderTop: 0

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -146,16 +146,17 @@
       zIndex: 43,
       height: '100vh',
       left: 0,
-      pointerEvents: 'none'
+      pointerEvents: 'all',
+      transition: '100ms opacity ease-out'
     },
     collapsed: {
-      display: 'none'
+      opacity: 0,
+      pointerEvents: 'none'
     },
     suggestions: {
       color: 'rgba(0,0,0,0.7)',
       width: 460,
       margin: '260px auto 0',
-      pointerEvents: 'all'
     },
     first: {
       borderTop: 0

--- a/src/browser/suggestion-box.js
+++ b/src/browser/suggestion-box.js
@@ -152,8 +152,8 @@
     },
     suggestions: {
       color: 'rgba(0,0,0,0.7)',
-      width: 460,
-      margin: '260px auto 0',
+      margin: '90px auto 0',
+      width: 460
     },
     first: {
       borderTop: 0

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -102,9 +102,10 @@
       setInputToURIBySelected(state));
 
   const closeWebViewByIndex = compose(
-    switchMode('edit-web-view', null),
-    selectInput,
+    switchMode('create-web-view', null),
     focusInput,
+    clearInput,
+    clearSuggestions,
     setInputToURIBySelected,
     (state, n) =>
       state.set('webViews', WebView.closeByIndex(state.webViews, n)));

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -131,12 +131,12 @@
     state => state.setIn(['input', 'value'], ''),
     clearSuggestions);
 
-
-  const fadeToSelectModefromShowMode = state =>
-    state.mode !== 'show-web-view' ? state :
-    fadeToSelectMode(state);
-
-  const showPreview = compose(fadeToSelectMode, blurInput);
+  const showPreview = compose(
+    fadeToSelectMode,
+    clearSuggestions,
+    clearInput,
+    blurInput
+  );
 
   const updateByWebViewIndex = (state, n, action) =>
     action instanceof Focusable.Focus ?

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -43,7 +43,7 @@
     state.merge({mode, transition});
 
   const fadeToEditMode = switchMode('edit-web-view', 'fade');
-  const zoomToEditMode = switchMode('edit-web-view', 'zoom');
+  const zoomToCreateMode = switchMode('create-web-view', 'zoom');
   const fadeToSelectMode = switchMode('select-web-view', 'fade');
   const fadeToShowMode = switchMode('show-web-view', 'fade');
 
@@ -126,16 +126,10 @@
     clearInput,
     navigate);
 
-  const zoomToEditModeFromShowMode = state =>
-    state.mode !== 'show-web-view' ? state :
-    zoomToEditMode(state);
-
-  const zoomEditSelectedWebView = compose(
-    zoomToEditModeFromShowMode,
-    selectInput,
-    focusInput,
-    clearSuggestions,
-    setInputToURIBySelected);
+  const zoomToSelectedPreview = compose(
+    state => state.mode !== 'show-web-view' ? state : zoomToCreateMode(state),
+    state => state.setIn(['input', 'value'], ''),
+    clearSuggestions);
 
 
   const fadeToSelectModefromShowMode = state =>
@@ -200,7 +194,7 @@
       updateBySelectedWebView(state, action.action) :
 
     action instanceof Gesture.Pinch ?
-      zoomEditSelectedWebView(state) :
+      zoomToSelectedPreview(state) :
     action instanceof ShowSelected ?
       completeSelection(state) :
     action instanceof ShowPreview ?

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -95,13 +95,12 @@
     fadeToEdit,
     selectInput,
     focusInput,
-    clearSuggestions,
     state =>
       state.mode === 'create-web-view' ? state :
       setInputToURIBySelected(state));
 
   const closeWebViewByIndex = compose(
-    switchMode('create-web-view', null),
+    fadeToCreateMode,
     focusInput,
     clearInput,
     clearSuggestions,

--- a/src/browser/synthesis-ui.js
+++ b/src/browser/synthesis-ui.js
@@ -44,6 +44,7 @@
 
   const fadeToEditMode = switchMode('edit-web-view', 'fade');
   const zoomToCreateMode = switchMode('create-web-view', 'zoom');
+  const fadeToCreateMode = switchMode('create-web-view', 'fade');
   const fadeToSelectMode = switchMode('select-web-view', 'fade');
   const fadeToShowMode = switchMode('show-web-view', 'fade');
 
@@ -65,16 +66,15 @@
     selectViewByIndex
   );
 
-  const createWebView = compose(
+  const createWebViewFade = compose(
+    fadeToCreateMode,
     focusInput,
-    (state, transition) =>
-      state.mode === 'create-web-view' ?
-      state :
-      state.mergeDeep({
-        mode: 'create-web-view',
-        input: {value: null},
-        transition
-      }));
+    clearInput);
+
+  const createWebViewZoom = compose(
+    zoomToCreateMode,
+    focusInput,
+    clearInput);
 
   const setInputToURIBySelected = state =>
     state.setIn(['input', 'value'],
@@ -97,7 +97,6 @@
     focusInput,
     clearSuggestions,
     state =>
-      state.mode === 'edit-web-view' ? state :
       state.mode === 'create-web-view' ? state :
       setInputToURIBySelected(state));
 
@@ -185,9 +184,9 @@
     action instanceof Input.Submit ?
       updateByInputAction(state, action) :
     action instanceof Preview.Create ?
-      createWebView(state, 'zoom') :
+      createWebViewZoom(state) :
     action instanceof OpenNew ?
-      createWebView(state, 'fade') :
+      createWebViewFade(state) :
 
     action instanceof WebView.ByID ?
       updateByWebViewID(state, action.id, action.action) :

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -78,11 +78,13 @@
       backgroundColor: 'transparent',
       border: '3px dashed rgba(255, 255, 255, 0.2)',
       boxShadow: 'none',
-      opacity: 0,
+      opacity: 1,
+      transform: 'scale(1)',
       transition: 'opacity 100ms linear, transform 80ms linear'
     },
-    appear: {
-      opacity: 1
+    disappear: {
+      opacity: 0,
+      transform: 'scale(0.9)',
     },
     selected: {
       transform: 'scale(1.05)'
@@ -233,7 +235,7 @@
       className: 'card',
       style: Style(stylePreview.card,
                    stylePreview.ghost,
-                   isVisible && stylePreview.appear)
+                   !isVisible && stylePreview.disappear)
     });
 
   const style = StyleSheet.create({

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -79,12 +79,10 @@
       border: '3px dashed rgba(255, 255, 255, 0.2)',
       boxShadow: 'none',
       opacity: 0,
-      transform: 'scale(.5)',
-      transition: 'opacity 100ms linear, transform 100ms linear'
+      transition: 'opacity 100ms linear, transform 80ms linear'
     },
     appear: {
-      opacity: 1,
-      transform: 'scale(1)'
+      opacity: 1
     },
     selected: {
       boxShadow: '0 0 0 6px #4A90E2'
@@ -256,10 +254,9 @@
       // Margin doesn't play well with scroll -- the right-hand edge will get
       // cut off, so we turn on the traditional CSS box model and use padding.
       boxSizing: 'content-box',
+      width: '100vw',
       // Fixed height to contain floats.
       height: '300px',
-      transform: 'translateX(-130px)',
-      transition: 'transform 200ms cubic-bezier(0.215, 0.610, 0.355, 1.000)',
       padding: 'calc(50vh - 150px) 200px 0 200px',
       margin: '0 auto',
     }
@@ -275,22 +272,21 @@
                address.forward(action =>
                                 WebView.ByID({id: loader.id, action}))));
 
-  const viewContainer = (isInputFocused, ...children) =>
+  const viewContainer = (theme, ...children) =>
     // Set the width of the previews element to match the width of each card
     // plus padding.
     html.div({key: 'preview-container', style: style.scroller}, [
-      html.div({
-        style: Style(style.previews,
-                     {width: children.length * 260},
-                     isInputFocused && {transform: 'translateX(0)'})},
-        children)]);
+      html.div({style: Style(style.previews, {
+        width: children.length * 260
+      })}, children)
+    ]);
 
-  const viewInEditMode = (loaders, pages, isInputFocused, selected, address) =>
-    viewContainer(isInputFocused, ...viewPreviews(loaders, pages, selected, address));
+  const viewInEditMode = (loaders, pages, isInputFocused, selected, theme, address) =>
+    viewContainer(theme, ...viewPreviews(loaders, pages, selected, address));
 
-  const viewInCreateMode = (loaders, pages, isInputFocused, selected, address) =>
+  const viewInCreateMode = (loaders, pages, isInputFocused, selected, theme, address) =>
     // Pass selected as `-1` so none is highlighted.
-    viewContainer(isInputFocused, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
+    viewContainer(theme, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
 
   const view = (mode, ...etc) =>
     mode === 'select-web-view' ? viewInEditMode(...etc) :

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -79,7 +79,7 @@
       border: '3px dashed rgba(255, 255, 255, 0.2)',
       boxShadow: 'none',
       opacity: 0,
-      transition: 'opacity 100ms linear'
+      transition: 'opacity 100ms linear, transform 80ms linear'
     },
     appear: {
       opacity: 1

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -79,10 +79,12 @@
       border: '3px dashed rgba(255, 255, 255, 0.2)',
       boxShadow: 'none',
       opacity: 0,
-      transition: 'opacity 100ms linear, transform 80ms linear'
+      transform: 'scale(.5)',
+      transition: 'opacity 100ms linear, transform 100ms linear'
     },
     appear: {
-      opacity: 1
+      opacity: 1,
+      transform: 'scale(1)'
     },
     selected: {
       boxShadow: '0 0 0 6px #4A90E2'
@@ -254,9 +256,10 @@
       // Margin doesn't play well with scroll -- the right-hand edge will get
       // cut off, so we turn on the traditional CSS box model and use padding.
       boxSizing: 'content-box',
-      width: '100vw',
       // Fixed height to contain floats.
       height: '300px',
+      transform: 'translateX(-130px)',
+      transition: 'transform 200ms cubic-bezier(0.215, 0.610, 0.355, 1.000)',
       padding: 'calc(50vh - 150px) 200px 0 200px',
       margin: '0 auto',
     }
@@ -272,21 +275,22 @@
                address.forward(action =>
                                 WebView.ByID({id: loader.id, action}))));
 
-  const viewContainer = (theme, ...children) =>
+  const viewContainer = (isInputFocused, ...children) =>
     // Set the width of the previews element to match the width of each card
     // plus padding.
     html.div({key: 'preview-container', style: style.scroller}, [
-      html.div({style: Style(style.previews, {
-        width: children.length * 260
-      })}, children)
-    ]);
+      html.div({
+        style: Style(style.previews,
+                     {width: children.length * 260},
+                     isInputFocused && {transform: 'translateX(0)'})},
+        children)]);
 
-  const viewInEditMode = (loaders, pages, isInputFocused, selected, theme, address) =>
-    viewContainer(theme, ...viewPreviews(loaders, pages, selected, address));
+  const viewInEditMode = (loaders, pages, isInputFocused, selected, address) =>
+    viewContainer(isInputFocused, ...viewPreviews(loaders, pages, selected, address));
 
-  const viewInCreateMode = (loaders, pages, isInputFocused, selected, theme, address) =>
+  const viewInCreateMode = (loaders, pages, isInputFocused, selected, address) =>
     // Pass selected as `-1` so none is highlighted.
-    viewContainer(theme, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
+    viewContainer(isInputFocused, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
 
   const view = (mode, ...etc) =>
     mode === 'create-web-view' ? viewInCreateMode(...etc) :

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -79,13 +79,13 @@
       border: '3px dashed rgba(255, 255, 255, 0.2)',
       boxShadow: 'none',
       opacity: 0,
-      transition: 'opacity 100ms linear, transform 80ms linear'
+      transition: 'opacity 100ms linear'
     },
     appear: {
       opacity: 1
     },
     selected: {
-      boxShadow: '0 0 0 6px #4A90E2'
+      transform: 'scale(1.05)'
     },
     header: {
       height: '24px',

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -77,7 +77,12 @@
     ghost: {
       backgroundColor: 'transparent',
       border: '3px dashed rgba(255, 255, 255, 0.2)',
-      boxShadow: 'none'
+      boxShadow: 'none',
+      opacity: 0,
+      transition: 'opacity 100ms linear'
+    },
+    appear: {
+      opacity: 1
     },
     selected: {
       boxShadow: '0 0 0 6px #4A90E2'
@@ -223,10 +228,13 @@
   };
   exports.viewPreview = viewPreview;
 
-  const ghostPreview = html.div({
-    className: 'card',
-    style: Style(stylePreview.card, stylePreview.ghost)
-  });
+  const viewGhost = (isVisible) =>
+    html.div({
+      className: 'card',
+      style: Style(stylePreview.card,
+                   stylePreview.ghost,
+                   isVisible && stylePreview.appear)
+    });
 
   const style = StyleSheet.create({
     scroller: {
@@ -273,12 +281,12 @@
       })}, children)
     ]);
 
-  const viewInEditMode = (loaders, pages, selected, theme, address) =>
-    viewContainer(theme, ghostPreview, ...viewPreviews(loaders, pages, selected, address));
+  const viewInEditMode = (loaders, pages, isInputFocused, selected, theme, address) =>
+    viewContainer(theme, ...viewPreviews(loaders, pages, selected, address));
 
-  const viewInCreateMode = (loaders, pages, selected, theme, address) =>
+  const viewInCreateMode = (loaders, pages, isInputFocused, selected, theme, address) =>
     // Pass selected as `-1` so none is highlighted.
-    viewContainer(theme, ghostPreview, ...viewPreviews(loaders, pages, -1, address));
+    viewContainer(theme, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
 
   const view = (mode, ...etc) =>
     mode === 'create-web-view' ? viewInCreateMode(...etc) :

--- a/src/browser/web-preview.js
+++ b/src/browser/web-preview.js
@@ -293,6 +293,6 @@
     viewContainer(isInputFocused, viewGhost(isInputFocused), ...viewPreviews(loaders, pages, -1, address));
 
   const view = (mode, ...etc) =>
-    mode === 'create-web-view' ? viewInCreateMode(...etc) :
-    viewInEditMode(...etc);
+    mode === 'select-web-view' ? viewInEditMode(...etc) :
+    viewInCreateMode(...etc);
   exports.view = view;


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/556.

Missing from this commit:

- Dynamically re-positioning tabs based on whether ghost tab is present. I think we need https://github.com/mozilla/browser.html/issues/577 for that.

Description:

create-web-view
- Cards are listed left-to-right in create-web-view (maybe it should be right-to-left, but this creates a weirdness with ctl tab. Maybe that's ok.)
- Focusing input will take you to the head of the list. Ghost card will appear.
- Unfocusing will make ghost card disappear and return viewport to where you were.
- Click plus takes you here. Input is focused.
- pinch/zoom from `show-web-view` takes you here, centered on current card. Input is not focused. Other than centering, there is no selected state.
- If the location bar has a value, we switch to search-view. You're conceptually editing the ghost tab. Hitting 'enter will fill ghost tab'.
- Closing a page will take you to create-web-view, centered on the next webview in the list (if any). The location bar is not focused unless there are no webviews.
- cmd clicking links will open links next to the page you're on, rather than at the head of the list (it's like rewriting history). They're opened in the background.

search-results
- edit-web-view is replaced by search-results view
- Search/edit is a full-window experience
- Clicking the 'x' button in the search box will return you to view-web-page of the selected web view, or to `create-web-view` if there are no web views.
- Clicking the location bar will take you to search mode. Unfocusing will take you back to page. Hitting enter will change tab location.

select-web-view
- This view is visually the same as `create-web-view`, except that input is never focused and ghost card is never shown.
- Selected style is identical to hover style

Motivation:

- Creates an obvious distinction between create view and edit view. Resolves the state edge cases currently present.
- In future, this will allow us to tie page-specific search-in-page into search box, since clicking on minimized location bar will transition straight to search view, where we can have suggestions about scope.