### PR TITLE
Implement page slide based navigation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser.html",
   "description": "browser.html",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "homepage": "https://github.com/mozilla/browser.html",
   "repository": {
     "type": "git",

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -196,6 +196,7 @@
           webViews.loader,
           webViews.shell,
           webViews.page,
+          webViews.sheet,
           address,
           webViews.selected)),
       render('DevtoolsHUD', DevtoolsHUD.view, state.devtoolsHUD, address),

--- a/src/browser/web-sheet.js
+++ b/src/browser/web-sheet.js
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
+
+import {Record, Union, List, Maybe, Any} from 'typed-immutable';
+
+// Model
+
+export const Model = Record({
+  isForced: Boolean,
+  isInMotion: Boolean,
+
+  x: Number,
+  width: Number,
+  delta: Number,
+  velocity: Number,
+  lastVelocity: Number,
+  image: Maybe(String),
+
+  forceTime: Maybe(Number),
+  moveTime: Maybe(Number)
+});
+
+export const init = () => Model({
+  isForced: false,
+  isInMotion: false,
+
+  image: null,
+  x: 0,
+  width: 0,
+  delta: 0,
+  velocity: 0,
+  lastVelocity: 0,
+
+  forceTime: null,
+  moveTime: null
+});
+
+// Action
+
+export const BeginSwipe = Record({
+  description: 'Begin swiping a sheet',
+  delta: Number,
+  width: Number,
+  timeStamp: Number
+}, 'Sheet.BeginSwipe');
+
+export const EndSwipe = Record({
+  description: 'End swiping a sheet',
+  timeStamp: Number
+}, 'Sheet.EndSwipe')
+
+export const ContinueSwipe = Record({
+  description: 'Continue swiping a sheet',
+  timeStamp: Number,
+  delta: Number
+}, 'Sheet.ContinueSwipe');
+
+export const AnimationFrame = Record({
+  description: 'Animating a sheet',
+  timeStamp: Number
+}, 'Sheet.AnimationFrame');
+
+export const Screenshot = Record({
+  description: 'Made screenshot',
+  image: String,
+}, 'Sheet.Screenshot');
+
+export const Action = Union(BeginSwipe, EndSwipe, ContinueSwipe,
+                            AnimationFrame, Screenshot);
+
+
+const stop = (state, _) => state.merge({
+  isInMotion: false,
+  isForced: false,
+
+  velocity: 0,
+  lastVelocity: 0,
+  x: 0,
+  delta: 0,
+  image: null,
+  width: 0,
+
+  moveTime: null,
+  forceTime: null
+});
+
+const force = (state, action) =>
+  !state.isForced ? state :
+    state.merge({
+      delta: action.delta,
+      forceTime: action.timeStamp,
+      lastVelocity: state.velocity,
+      velocity: (action.delta - state.delta) /
+                (action.timeStamp / state.forceTime)
+    });
+
+const move = (state, action) => {
+  const x = state.x + Math.floor((action.timeStamp - state.moveTime) * state.velocity * 70);
+
+  return Math.abs(x) >= state.width ?
+            stop(state) :
+          x <= 0 && state.x > 0 ? stop(state) :
+          x >= 0 && state.x < 0 ? stop(state) :
+            state.merge({
+              moveTime: action.timeStamp,
+              x
+            });
+};
+
+const touch = (state, action) => state.merge({
+  isForced: true,
+  isInMotion: true,
+  x: 0,
+  delta: action.delta,
+  velocity: 0,
+  width: action.width,
+
+  forceTime: action.timeStamp,
+  moveTime: action.timeStamp
+});
+
+// If when released it's not passed the trethold area then allow
+// spring force to move it back to the starting point. Otherwise
+// release the force and let the momentum take over.
+const release = (state, action) =>
+  Math.abs(state.x) < (state.width / 2) ? state :
+  state.merge({isForced: false,
+              // Hack: It seems that just before MozSwipeGesture we receive
+              // MozSwipeGestureUpdate with a same delta as previous one and
+              // we end up with velocity 0. Note we can't just ignore such
+              // MozSwipeGestureUpdate events as user in fact may stop swiping
+              // without releasing a touch which we would not like to ignore.
+               velocity: state.lastVelocity});
+
+const physics = (state, action) =>
+  action instanceof BeginSwipe ?
+    touch(state, action) :
+  !state.isInMotion ?
+    state :
+  action instanceof EndSwipe ?
+    release(state, action) :
+  action instanceof ContinueSwipe ?
+    force(state, action) :
+  action instanceof AnimationFrame ?
+    move(state, action) :
+    state;
+
+export const update = (state, action) =>
+  action instanceof Screenshot ?
+    state.set('image', action.image) :
+  physics(state, action);

--- a/src/common/animation.js
+++ b/src/common/animation.js
@@ -47,7 +47,9 @@
       this.componentDidUpdate();
     }
     componentDidUpdate() {
-      Animation.schedule(this);
+      if (this.props.isActive) {
+        Animation.schedule(this);
+      }
     }
     onAnimationFrame(event) {
       if (this.props.onAnimationFrame) {
@@ -62,14 +64,15 @@
 
   // Utility for re-rendering `target` on every animation frame. This is useful
   // when components need to react to passed time and not some user event.
-  const animate = (target, onAnimationFrame) => {
+  const animate = (target, onAnimationFrame, isActive=true) => {
     if (typeof(onAnimationFrame) != 'function') {
       throw TypeError('animate must be given function as a second argument');
     }
 
     return React.createElement(Animation, {
       key: target.key, target,
-      onAnimationFrame
+      onAnimationFrame,
+      isActive
     });
   }
 


### PR DESCRIPTION
@gordonbrander this is an attempt to implement page slide based go back / forward, but unfortunately it's unusable as screenshots arrive just too late, usually when the sliding page is about slide out of viewport. And when it does it render image it causes junk.

P.S.: I have not actually hooked up navigation events because idea was to trigger goBack after we have a screenshot but this just unusable to be worth finishing.

Related to #646