### PR TITLE
Migrate to new package.json license format

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,5 @@
     "vinyl-source-stream": "1.1.0",
     "watchify": "3.3.1"
   },
-  "licenses": [
-    {
-      "type": "MPL",
-      "version": "2.0",
-      "url": "http://mozilla.org/MPL/2.0/"
-    }
-  ]
+  "license": "MPL-2.0"
 }


### PR DESCRIPTION
Removes the following warning:

```
npm WARN package.json browser.html@0.0.8 No license field.
```

More info here:

https://docs.npmjs.com/files/package.json#license