### PR TITLE
Move children of Browser.view out to PerspectiveUI

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -7,7 +7,6 @@ import * as Shell from "./shell";
 import * as Input from "./input";
 import * as Assistant from "./assistant";
 import * as WindowControls from "./window-controls";
-import * as Sidebar from "./sidebar";
 
 // import * as Updater from "./updater"
 // import * as Devtools from "./devtools"
@@ -159,7 +158,7 @@ const style = StyleSheet.create({
   }
 });
 
-export const view/*:type.view*/ = (model, address) =>
+export const view/*:type.view*/ = (model, children, address) =>
   html.div({
     className: 'root',
     style: style.root,
@@ -170,22 +169,7 @@ export const view/*:type.view*/ = (model, address) =>
     onFocus: onWindow(forward(address, asFor("shell")), Focusable.asFocus),
     // onUnload: () => address(Session.SaveSession),
   }, [
-    thunk('web-views',
-          WebViews.view,
-          model.webViews,
-          forward(address, asFor("webViews"))),
-    thunk('sidebar',
-          Sidebar.view,
-          model.webViews,
-          forward(address, asFor("webViews"))),
-    thunk('input',
-          Input.view,
-          model.input,
-          forward(address, asFor("input"))),
-    thunk('suggestions',
-          Assistant.view,
-          model.suggestions,
-          address),
+    ...children,
     thunk('controls',
       WindowControls.view,
       model.shell,

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -1,7 +1,12 @@
 /* @flow */
 
-import * as Browser from "./browser";
-import {merge} from "../common/prelude";
+import {forward, thunk} from 'reflex';
+import * as Input from './input';
+import * as Assistant from './assistant';
+import * as Sidebar from './sidebar';
+import * as Browser from './browser';
+import * as WebViews from './web-views';
+import {asFor, merge} from '../common/prelude';
 
 export const initialize/*:type.initialize*/ = () => {
   const [browser, fx] = Browser.initialize();
@@ -165,5 +170,22 @@ export const step = (model, action) => {
   return [merge(model, {browser}), fx];
 }
 
-export const view = (model, address) =>
-  Browser.view(model.browser, address);
+export const view = ({browser}, address) =>
+  Browser.view(browser, [
+    thunk('web-views',
+          WebViews.view,
+          browser.webViews,
+          forward(address, asFor('webViews'))),
+    thunk('sidebar',
+          Sidebar.view,
+          browser.webViews,
+          forward(address, asFor('webViews'))),
+    thunk('input',
+          Input.view,
+          browser.input,
+          forward(address, asFor('input'))),
+    thunk('suggestions',
+          Assistant.view,
+          browser.suggestions,
+          address)
+  ], address);


### PR DESCRIPTION
This gives us the structure we'll need to implement modes in `PerspectiveUI.view`.