### PR TITLE
Use keyup event instead of input event for observing input updates.

### DIFF
--- a/src/browser/input.js
+++ b/src/browser/input.js
@@ -171,7 +171,10 @@ export const view = (model, address, modeStyle) =>
       // keys or when you click in the input field. There for we
       // need to handle those events to keep our model in sync with
       // actul input field state.
-      onKeyUp: on(address, readSelect),
+
+      // @HACK In servo input event does not seem to fire as expected
+      // so we use onKeyUp instead here.
+      onKeyUp: on(address, readChange),
       onMouseOut: on(address, readSelect)
     })
   ]);


### PR DESCRIPTION
@paulrouget use of keyup event seems to have some issues when typing fast (one you mentioned in the meeting) but even on gecko. I get an impression that when `keyup` is fired `input.value` has not yet changed, but it maybe something different. I'll try to work it out what happens tomorrow, but for now you can try merging this for testing on servo if you like.