### PR TITLE
Bind events to target.owner document

### DIFF
--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -118,7 +118,7 @@ export const on = (address, decode, options, getTarget) => {
   return address[id]
 }
 
-const getRoot = target => target.ownerDocument.documentElement
+const getRoot = target => target.ownerDocument
 export const onWindow = (address, decode, options) =>
   on(address, decode, options, getRoot)
 


### PR DESCRIPTION
We used target.ownerDocument.documentElement for event binding, since
servo doesn't yet bubble events to window. However,
target.ownerDocument.documentElement does not receive window focus/blur
events, which we need for windowcontrols.

This commit switches to target.ownerDocument for event binding in the
hopes that this will work for Servo. I'm not sure how to test that.

cc @paulrouget