### PR TITLE
Separate animation for show-tabs -> show-webview when pinned

### DIFF
--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -455,6 +455,14 @@ const style = StyleSheet.create({
 
   },
 
+  suggestionsShrink: {
+    width: 'calc(100% - 50px)'
+  },
+
+  suggestionsExpand: {
+
+  },
+
   assistantHidden: {
     display: 'none'
   },
@@ -500,7 +508,11 @@ const viewAsEditWebView = (model, address) =>
     thunk('suggestions',
           Assistant.view,
           model.browser.suggestions,
-          address),
+          address,
+          Style(
+                model.sidebar.isAttached
+                ? style.suggestionsShrink
+                : style.suggestionsExpand)),
     thunk('input',
           Input.view,
           model.browser.input,

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -151,7 +151,7 @@ export const isSwitchSelectedWebView = action =>
 export const asByAnimation = asFor('animation');
 export const asByWebViews = asFor('webViews');
 
-export const showTabsTransitionDuration = 600;
+export const showTabsTransitionDuration = 500;
 export const hideTabsTransitionDuration = 200;
 
 

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -455,14 +455,6 @@ const style = StyleSheet.create({
 
   },
 
-  suggestionsShrink: {
-    width: 'calc(100% - 50px)'
-  },
-
-  suggestionsExpand: {
-
-  },
-
   assistantHidden: {
     display: 'none'
   },
@@ -508,10 +500,7 @@ const viewAsEditWebView = (model, address) =>
     thunk('suggestions',
           Assistant.view,
           model.browser.suggestions,
-          address,
-          Style(  model.sidebar.isAttached
-                ? style.suggestionsShrink
-                : style.suggestionsExpand)),
+          address),
     thunk('input',
           Input.view,
           model.browser.input,

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -509,8 +509,7 @@ const viewAsEditWebView = (model, address) =>
           Assistant.view,
           model.browser.suggestions,
           address,
-          Style(
-                model.sidebar.isAttached
+          Style(  model.sidebar.isAttached
                 ? style.suggestionsShrink
                 : style.suggestionsExpand)),
     thunk('input',

--- a/src/browser/sidebar.js
+++ b/src/browser/sidebar.js
@@ -155,18 +155,7 @@ const animationProjection = model =>
      titleOpacity: 1,
      tabWidth: 312}
 
-const animationDuration = model =>
-    model.isOpen
-  ? ( model.isAttached
-    ? 500
-    : 600
-    )
-  : ( model.isAttached
-    ? 350
-    : 400
-    );
-
-
+const animationDuration = model => model.isOpen ? 500 : 200;
 
 const animate = (model, action) => {
   const [{animation}, fx] = stopwatch(model, action.action)

--- a/src/browser/sidebar.js
+++ b/src/browser/sidebar.js
@@ -82,7 +82,14 @@ export const init = () => {
       isAttached: false,
       isOpen: false,
       animation: null,
-      display: {x: 500, shadow: 0.5, spacing: 34, titleOpacity: 1, tabWidth: 312},
+      display: {
+        x: 500,
+        shadow: 0.5,
+        spacing: 34,
+        toolbarOpacity: 1,
+        titleOpacity: 1,
+        tabWidth: 312
+      },
       toolbar
     },
     fx.map(ToolbarAction)
@@ -120,16 +127,32 @@ const interpolate = (from, to, progress) => merge(from, {
   x: Easing.float(from.x, to.x, progress),
   shadow: Easing.float(from.shadow, to.shadow, progress),
   spacing: Easing.float(from.spacing, to.spacing, progress),
+  toolbarOpacity: Easing.float(from.toolbarOpacity, to.toolbarOpacity, progress),
   titleOpacity: Easing.float(from.titleOpacity, to.titleOpacity, progress),
   tabWidth: Easing.float(from.tabWidth, to.tabWidth, progress)
 })
 
 const animationProjection = model =>
     model.isOpen
-  ? {x: 0, shadow: 0.5, spacing: 34, titleOpacity: 1, tabWidth: 312}
+  ? {x: 0,
+     shadow: 0.5,
+     spacing: 34,
+     toolbarOpacity: 1,
+     titleOpacity: 1,
+     tabWidth: 312}
   : model.isAttached
-  ? {x: 330, shadow: 0, spacing: 8, titleOpacity: 0, tabWidth: 34}
-  : {x: 500, shadow: 0.5, spacing: 34, titleOpacity: 1, tabWidth: 312}
+  ? {x: 330,
+     shadow: 0,
+     spacing: 8,
+     toolbarOpacity: 0,
+     titleOpacity: 0,
+     tabWidth: 34}
+  : {x: 500,
+     shadow: 0.5,
+     spacing: 34,
+     toolbarOpacity: 1,
+     titleOpacity: 1,
+     tabWidth: 312}
 
 const animationDuration = model =>
     model.isOpen
@@ -154,10 +177,25 @@ const animate = (model, action) => {
   // something that will give us more like spring physics.
   const begin
     = !model.isOpen
-    ? {x: 0, shadow: 0.5, spacing: 34, titleOpacity: 1, tabWidth: 312}
+    ? {x: 0,
+       shadow: 0.5,
+       spacing: 34,
+       toolbarOpacity: 1,
+       titleOpacity: 1,
+       tabWidth: 312}
     : model.isAttached
-    ? {x: 330, shadow: 0, spacing: 8, titleOpacity: 0, tabWidth: 34}
-    : {x: 500, shadow: 0.5, spacing: 34, titleOpacity: 1, tabWidth: 312};
+    ? {x: 330,
+       shadow: 0,
+       spacing: 8,
+       toolbarOpacity: 0,
+       titleOpacity: 0,
+       tabWidth: 34}
+    : {x: 500,
+       shadow: 0.5,
+       spacing: 34,
+       toolbarOpacity: 0,
+       titleOpacity: 1,
+       tabWidth: 312};
 
   const projection = animationProjection(model)
 
@@ -274,7 +312,8 @@ const viewSidebar = (key) => (model, {entries}, address) => {
     thunk('sidebar-toolbar',
           Toolbar.view,
           model.toolbar,
-          forward(address, ToolbarAction))
+          forward(address, ToolbarAction),
+          display)
   ]);
 }
 

--- a/src/browser/sidebar.js
+++ b/src/browser/sidebar.js
@@ -21,6 +21,7 @@ const styles = StyleSheet.create({
     // WARNING: will slow down animations! (gecko)
     // boxShadow: 'rgba(0, 0, 0, 0.5) -50px 0 80px',
     backgroundColor: '#24303D',
+    willChange: 'box-shadow',
     height: '100%',
     position: 'absolute',
     right: 0,

--- a/src/browser/sidebar/toolbar.js
+++ b/src/browser/sidebar/toolbar.js
@@ -76,11 +76,14 @@ const viewPin = Toggle.view('pin-button', StyleSheet.create({
   }
 }));
 
-export const view = (model, address) =>
+export const view = (model, address, {toolbarOpacity}) =>
   html.div({
     key: 'sidebar-toolbar',
     className: 'sidebar-toolbar',
-    style: styleSheet.toolbar
+    style: Style(
+      styleSheet.toolbar,
+      {opacity: toolbarOpacity}
+    )
   }, [
     thunk('pin', viewPin, model.pin, forward(address, Pin))
   ]);


### PR DESCRIPTION
This cleans up many of the animation details for `show-tabs -> show-webview` when pinned.

- Tabs are animated to their "mini" version
- Sidebar toolbar is faded out

Still todo

- Set width of suggestions box to width of webviews
- Show hamburger menu and + button in pinned sidebar (not webview)

Going to address the last 2 in follow-up PRs as they require some markup restructuring.