### PR TITLE
Wrap webviews, overlay, suggestions, input in common div

### DIFF
--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -457,6 +457,7 @@ const style = StyleSheet.create({
 
   content: {
     position: 'absolute',
+    perspective: '1000px',
     height: '100%',
     width: '100%',
   },
@@ -497,13 +498,16 @@ const viewAsEditWebView = (model, address) =>
     html.div({
       className: 'content',
       style: Style(
+        style.content,
         model.sidebar.isAttached ?
-          style.contentShrink : style.contentExpand)
+          style.contentShrink : style.contentExpand
+      )
     }, [
       thunk('web-views',
             WebViews.view,
             model.browser.webViews,
-            forward(address, asFor('webViews'))),
+            forward(address, asFor('webViews')),
+            style.webViewZoomedIn),
       thunk('overlay',
           Overlay.view,
           model.overlay,
@@ -522,132 +526,156 @@ const viewAsEditWebView = (model, address) =>
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
-          forward(address, SidebarAction)),
+          forward(address, SidebarAction))
   ]);
 
 const viewAsShowWebView = (model, address) =>
   Browser.view(model.browser, address, [
-    thunk('web-views',
-          WebViews.view,
-          model.browser.webViews,
-          forward(address, asFor('webViews')),
-          Style(  model.sidebar.isAttached
-                ? style.webViewShrink
-                : style.webViewExpand,
-                transition.webViewZoomIn(model.animation))),
-    thunk('overlay',
-          Overlay.view,
-          model.overlay,
-          forward(address, OverlayAction)),
+    html.div({
+      className: 'content',
+      style: Style(
+        style.content,
+        model.sidebar.isAttached ?
+          style.contentShrink : style.contentExpand
+      )
+    }, [
+      thunk('web-views',
+            WebViews.view,
+            model.browser.webViews,
+            forward(address, asFor('webViews')),
+            transition.webViewZoomIn(model.animation)),
+      thunk('overlay',
+            Overlay.view,
+            model.overlay,
+            forward(address, OverlayAction)),
+      thunk('suggestions',
+            Assistant.view,
+            model.browser.suggestions,
+            address,
+            style.assistantHidden),
+      thunk('input',
+            Input.view,
+            model.browser.input,
+            forward(address, asFor('input')),
+            style.inputHidden)
+    ]),
     thunk('sidebar',
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
-          forward(address, SidebarAction)),
-    thunk('suggestions',
-          Assistant.view,
-          model.browser.suggestions,
-          address,
-          style.assistantHidden),
-    thunk('input',
-          Input.view,
-          model.browser.input,
-          forward(address, asFor('input')),
-          style.inputHidden)
+          forward(address, SidebarAction))
   ]);
 
 const viewAsCreateWebView = (model, address) =>
   Browser.view(model.browser, address, [
-    thunk('web-views',
-          WebViews.view,
-          model.browser.webViews,
-          forward(address, asFor('webViews')),
-          Style(style.webViewZoomedOut,
-                  model.sidebar.isAttached
-                ? style.webViewShrink
-                : style.webViewExpand,
-                transition.webViewZoomIn(model.animation))),
-    thunk('overlay',
-          Overlay.view,
-          model.overlay,
-          forward(address, OverlayAction)),
+    html.div({
+      className: 'content',
+      style: Style(
+        style.content,
+        model.sidebar.isAttached ?
+          style.contentShrink : style.contentExpand
+      )
+    }, [
+      thunk('web-views',
+            WebViews.view,
+            model.browser.webViews,
+            forward(address, asFor('webViews')),
+            Style(style.webViewZoomedOut,
+                  transition.webViewZoomIn(model.animation))),
+      thunk('overlay',
+            Overlay.view,
+            model.overlay,
+            forward(address, OverlayAction)),
+      thunk('suggestions',
+            Assistant.view,
+            model.browser.suggestions,
+            address,
+            style.assistantFull),
+      thunk('input',
+            Input.view,
+            model.browser.input,
+            forward(address, asFor('input')),
+            style.inputVisible)
+    ]),
     thunk('sidebar',
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
-          forward(address, SidebarAction)),
-    thunk('suggestions',
-          Assistant.view,
-          model.browser.suggestions,
-          address,
-          style.assistantFull),
-    thunk('input',
-          Input.view,
-          model.browser.input,
-          forward(address, asFor('input')),
-          style.inputVisible)
+          forward(address, SidebarAction))
   ]);
 
 const viewAsSelectWebView = (model, address) =>
   Browser.view(model.browser, address, [
-    thunk('web-views',
-          WebViews.view,
-          model.browser.webViews,
-          forward(address, asFor('webViews')),
-          Style(style.webViewZoomedOut,
-                  model.sidebar.isAttached
-                ? style.webViewShrink
-                : style.webViewExpand,
-                transition.webViewZoomOut(model.animation))),
-    thunk('overlay',
-          Overlay.view,
-          model.overlay,
-          forward(address, OverlayAction)),
+    html.div({
+      className: 'content',
+      style: Style(
+        style.content,
+        model.sidebar.isAttached ?
+          style.contentShrink : style.contentExpand
+      )
+    }, [
+      thunk('web-views',
+            WebViews.view,
+            model.browser.webViews,
+            forward(address, asFor('webViews')),
+            Style(style.webViewZoomedOut,
+                  transition.webViewZoomOut(model.animation))),
+      thunk('overlay',
+            Overlay.view,
+            model.overlay,
+            forward(address, OverlayAction)),
+      thunk('suggestions',
+            Assistant.view,
+            model.browser.suggestions,
+            address,
+            style.assistantHidden),
+      thunk('input',
+            Input.view,
+            model.browser.input,
+            forward(address, asFor('input')),
+            style.inputHidden)
+    ]),
     thunk('sidebar',
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
-          forward(address, SidebarAction)),
-    thunk('suggestions',
-          Assistant.view,
-          model.browser.suggestions,
-          address,
-          style.assistantHidden),
-    thunk('input',
-          Input.view,
-          model.browser.input,
-          forward(address, asFor('input')),
-          style.inputHidden)
+          forward(address, SidebarAction))
   ]);
 
 const viewAsShowTabs = (model, address) =>
   Browser.view(model.browser, address, [
-    thunk('web-views',
-          WebViews.view,
-          model.browser.webViews,
-          forward(address, asFor('webViews')),
-          Style(style.webViewZoomedOut,
-                  model.sidebar.isAttached
-                ? style.webViewShrink
-                : style.webViewExpand,
-                transition.webViewZoomOut(model.animation))),
-    thunk('overlay',
-          Overlay.view,
-          model.overlay,
-          forward(address, OverlayAction)),
+    html.div({
+      className: 'content',
+      style: Style(
+        style.content,
+        model.sidebar.isAttached ?
+          style.contentShrink : style.contentExpand
+      )
+    }, [
+      thunk('web-views',
+            WebViews.view,
+            model.browser.webViews,
+            forward(address, asFor('webViews')),
+            Style(style.webViewZoomedOut,
+                  transition.webViewZoomOut(model.animation))),
+      thunk('overlay',
+            Overlay.view,
+            model.overlay,
+            forward(address, OverlayAction)),
+      thunk('suggestions',
+            Assistant.view,
+            model.browser.suggestions,
+            address,
+            style.assistantHidden),
+      thunk('input',
+            Input.view,
+            model.browser.input,
+            forward(address, asFor('input')),
+            style.inputHidden)
+    ]),
     thunk('sidebar',
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
-          forward(address, SidebarAction)),
-    thunk('suggestions',
-          Assistant.view,
-          model.browser.suggestions,
-          address,
-          style.assistantHidden),
-    thunk('input',
-          Input.view,
-          model.browser.input,
-          forward(address, asFor('input')),
-          style.inputHidden)
+          forward(address, SidebarAction))
   ]);

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {forward, thunk, Effects} from 'reflex';
+import {forward, html, thunk, Effects} from 'reflex';
 import * as Input from './input';
 import * as Assistant from './assistant';
 import * as Sidebar from './sidebar';
@@ -455,6 +455,20 @@ const style = StyleSheet.create({
 
   },
 
+  content: {
+    position: 'absolute',
+    height: '100%',
+    width: '100%',
+  },
+
+  contentShrink: {
+    width: 'calc(100% - 50px)'
+  },
+
+  contentExpand: {
+    width: '100%'
+  },
+
   assistantHidden: {
     display: 'none'
   },
@@ -480,32 +494,35 @@ export const view = (model, address) =>
 
 const viewAsEditWebView = (model, address) =>
   Browser.view(model.browser, address, [
-    thunk('web-views',
-          WebViews.view,
-          model.browser.webViews,
-          forward(address, asFor('webViews')),
-          Style(  model.sidebar.isAttached
-                ? style.webViewShrink
-                : style.webViewExpand,
-                  style.webViewZoomedIn)),
-    thunk('overlay',
+    html.div({
+      className: 'content',
+      style: Style(
+        model.sidebar.isAttached ?
+          style.contentShrink : style.contentExpand)
+    }, [
+      thunk('web-views',
+            WebViews.view,
+            model.browser.webViews,
+            forward(address, asFor('webViews'))),
+      thunk('overlay',
           Overlay.view,
           model.overlay,
           forward(address, OverlayAction)),
+      thunk('suggestions',
+            Assistant.view,
+            model.browser.suggestions,
+            address),
+      thunk('input',
+            Input.view,
+            model.browser.input,
+            forward(address, asFor('input')),
+            style.inputVisible)
+    ]),
     thunk('sidebar',
           Sidebar.view,
           model.sidebar,
           model.browser.webViews,
           forward(address, SidebarAction)),
-    thunk('suggestions',
-          Assistant.view,
-          model.browser.suggestions,
-          address),
-    thunk('input',
-          Input.view,
-          model.browser.input,
-          forward(address, asFor('input')),
-          style.inputVisible)
   ]);
 
 const viewAsShowWebView = (model, address) =>


### PR DESCRIPTION
This lets us set the div's width when pinning the sidebar, so everything lines up correctly.