### PR TITLE
Fix input styles

### DIFF
--- a/src/browser/input.js
+++ b/src/browser/input.js
@@ -155,31 +155,36 @@ const readSelect = compose
       Editable.Select(readSelection(target))
   );
 
-const inputWidth = '460px';
-const inputHeight = '40px';
+const inputWidth = 460;
+const inputHeight = 40;
+const inputXPadding = 32;
 
 const style = StyleSheet.create({
   combobox: {
-    background: '#EBEEF2',
-    borderRadius: '5px',
     height: inputHeight,
     left: '50%',
-    marginLeft: `calc(-1 * (${inputWidth} / 2))`,
+    marginLeft: `calc(-1 * (${inputWidth}px / 2))`,
     position: 'absolute',
     top: '40px',
-    width: inputWidth
+    width: `${inputWidth}px`
   },
   field: {
-    background: 'transparent',
-    borderWidth: 0,
+    background: '#EBEEF2',
+    borderRadius: '5px',
+    borderWidth: '3px',
+    borderStyle: 'solid',
+    borderColor: 'transparent',
     display: 'block',
     fontSize: '14px',
     MozAppearance: 'none',
-    height: inputHeight,
-    lineHeight: inputHeight,
+    height: `${inputHeight - 6}px`,
+    lineHeight: `${inputHeight - 6}px`,
     margin: 0,
-    padding: '0 32px',
-    width: `calc(${inputWidth} - ${32 * 2}px)`
+    padding: `0 ${inputXPadding}px`,
+    width: `calc(${inputWidth - 6}px - ${inputXPadding * 2}px)`
+  },
+  fieldFocused: {
+    borderColor: '#3D91F2'
   },
   inactive: {
     opacity: 0,
@@ -236,7 +241,9 @@ export const view/*:type.view*/ = (model, address) =>
     html.input({
       className: 'input-field',
       placeholder: 'Search or enter address',
-      style: style.field,
+      style: Style( style.field
+                  , model.isFocused && style.fieldFocused
+                  ),
       type: 'text',
       value: model.value,
       isFocused: focus(model.isFocused),

--- a/src/browser/input.js
+++ b/src/browser/input.js
@@ -205,9 +205,6 @@ const style = StyleSheet.create({
   clearIconInactive: {
     opacity: 0
   },
-  visible: {
-
-  },
   hidden: {
     opacity: 0,
     pointerEvents: 'none'
@@ -218,9 +215,7 @@ export const view/*:type.view*/ = (model, address) =>
   html.div({
     className: 'input-combobox',
     style: Style( style.combobox
-                ,   model.isVisible
-                  ? style.visible
-                  : style.hidden
+                , !model.isVisible && style.hidden
                 )
   }, [
     html.span({

--- a/src/browser/input.js
+++ b/src/browser/input.js
@@ -166,9 +166,8 @@ const style = StyleSheet.create({
     left: '50%',
     marginLeft: `calc(-1 * (${inputWidth} / 2))`,
     position: 'absolute',
-    padding: '0 32px',
     top: '40px',
-    width: `calc(${inputWidth} - ${32 * 2}px)`
+    width: inputWidth
   },
   field: {
     background: 'transparent',
@@ -179,7 +178,7 @@ const style = StyleSheet.create({
     height: inputHeight,
     lineHeight: inputHeight,
     margin: 0,
-    padding: 0,
+    padding: '0 32px',
     width: `calc(${inputWidth} - ${32 * 2}px)`
   },
   inactive: {

--- a/src/browser/input.js
+++ b/src/browser/input.js
@@ -163,7 +163,7 @@ const style = StyleSheet.create({
   combobox: {
     height: inputHeight,
     left: '50%',
-    marginLeft: `calc(-1 * (${inputWidth}px / 2))`,
+    marginLeft: `${-1 * (inputWidth / 2)}px`,
     position: 'absolute',
     top: '40px',
     width: `${inputWidth}px`
@@ -181,7 +181,7 @@ const style = StyleSheet.create({
     lineHeight: `${inputHeight - 6}px`,
     margin: 0,
     padding: `0 ${inputXPadding}px`,
-    width: `calc(${inputWidth - 6}px - ${inputXPadding * 2}px)`
+    width: `${(inputWidth - 6) - (inputXPadding * 2)}px`
   },
   fieldFocused: {
     borderColor: '#3D91F2'


### PR DESCRIPTION
Fixes https://github.com/mozilla/browser.html/issues/826.

- Move icon padding from input wrapper to input. This won't fix the dotted focus line in Servo, but it will at least make it wrap around the input instead of a random box.
- Add focus border to input.