### PR TITLE
Do not select tab on close button click.

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -86,8 +86,6 @@ const SidebarAction = action =>
   ? CreateWebView
   : action.type === "ActivateTab"
   ? ActivateWebViewByID(action.id)
-  : action.type === "SelectTab"
-  ? SelectWebViewByID(action.id)
   : action.type === "CloseTab"
   ? CloseWebViewByID(action.id)
   : action.type === "Tabs"
@@ -133,16 +131,12 @@ const WebViewsAction = action =>
   ? { type: "SelectTab"
     , source: action
     }
-  : action.type === "SelectByID"
-  ? { type: "SelectTabByID"
-    , source: action
-    }
   : action.type === "ActivateSelected"
   ? { type: "ActivateTab"
     , source: action
     }
   : action.type === "ActivateByID"
-  ? { type: "ActivateTab"
+  ? { type: "ActivateTabByID"
     , source: action
     }
   : { type: 'WebViews'
@@ -362,8 +356,6 @@ const OpenURL = ({url}) =>
 
 export const ActivateWebViewByID =
   compose(WebViewsAction, WebViews.ActivateByID);
-const SelectWebViewByID =
-  compose(WebViewsAction, WebViews.SelectByID);
 const WebViewActionByID =
   compose(WebViewsAction, WebViews.ActionByID);
 
@@ -734,7 +726,7 @@ export const update/*:type.update*/ = (model, action) =>
   ? updateWebViews(model, action.source)
   : action.type === 'SelectTab'
   ? updateWebViews(model, action.source)
-  : action.type === 'SelectTabByID'
+  : action.type === 'ActivateTabByID'
   ? updateWebViews(model, action.source)
   : action.type === 'ActivateTab'
   ? updateWebViews(model, action.source)

--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -80,7 +80,7 @@ export const update = (model, action) =>
     ? Browser.update(model, Browser.ShowTabs)
     // When tab is selected in show-web-view mode activate
     // select-web-view mode & delegate original action.
-    : action.type === 'SelectTab'
+    : action.type === 'ActivateTab'
     ? batch
       ( Browser.update
       , model
@@ -106,7 +106,7 @@ export const update = (model, action) =>
     ? Browser.update(model, Browser.ShowWebView)
     : action.type === 'OverlayClicked'
     ? Browser.update(model, Browser.ShowWebView)
-    : action.type === 'SelectTabByID'
+    : action.type === 'ActivateTabByID'
     ? batch
       ( Browser.update
       , model
@@ -114,7 +114,7 @@ export const update = (model, action) =>
         , Browser.ShowWebView
         ]
       )
-    : action.type === 'SelectTab'
+    : action.type === 'ActivateTab'
     ? batch
       ( Browser.update
       , model

--- a/src/browser/sidebar.js
+++ b/src/browser/sidebar.js
@@ -65,20 +65,15 @@ export const Detach =
 
 export const Open = {type: "Open"};
 export const Close = {type: "Close"};
-export const Select = {type: "Select"};
 export const Activate = {type: "Activate"};
 export const CloseTab/*:type.CloseTab*/ = id =>
   ({type: "CloseTab", id});
-export const SelectTab/*:type.SelectTab*/ = id =>
-  ({type: "SelectTab", id});
 export const ActivateTab/*:type.ActivateTab*/ = id =>
   ({type: "ActivateTab", id});
 
 const TabsAction = action =>
   (  action.type === "Close"
   ? CloseTab(action.id)
-  : action.type === "Select"
-  ? SelectTab(action.id)
   : action.type === "Activate"
   ? ActivateTab(action.id)
   : { type: "Tabs"

--- a/src/browser/sidebar/tab.js
+++ b/src/browser/sidebar/tab.js
@@ -180,7 +180,6 @@ export const view/*:type.view*/ = (model, address, {tabWidth, titleOpacity}) =>
       )
     , onMouseOver: forward(address, always(Over))
     , onMouseOut: forward(address, always(Out))
-    , onMouseDown: forward(address, always(Select))
     , onMouseUp: forward(address, always(Activate))
     }
   , [ html.div

--- a/src/browser/sidebar/tabs.js
+++ b/src/browser/sidebar/tabs.js
@@ -31,11 +31,6 @@ export const Close/*:type.Close*/ = id =>
     }
   );
 
-export const Select/*:type.Select*/ = id =>
-  ( { type: "Select"
-    , id
-    }
-  );
 
 export const Activate/*:type.Activate*/ = id =>
   ( { type: "Activate"
@@ -48,8 +43,6 @@ export const ByID/*:type.ByID*/ =
   action =>
   ( action.type === "Close"
   ? Close(id)
-  : action.type === "Select"
-  ? Select(id)
   : action.type === "Activate"
   ? Activate(id)
   : { type: "Tab"


### PR DESCRIPTION
Fixes #849 

Clicking tab close button was triggering `onMouseDown` of the tab container triggering `TabSelect` action that was starting an animation & as a consequence `onClick` on close button was no longer triggered which cased unreliable tab closing behavior.

As a matter of fact `Select` action was not required and was more of leftover from post refactoring codebase.