### PR TITLE
Open new tabs on link click

### DIFF
--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -871,9 +871,19 @@ const decodeClose = always(Close);
 const decodeDetail = ({detail}) => detail;
 const decodeTime = ({detail}) => performance.now();
 
+// Detail is different in each case, so we define a special reader function
+// for this particular case.
+const decodeOpenDetail = ({detail}) =>
+  ( { frameElement: detail.frameElement
+    // Change url to uri for naming consistency.
+    , uri: detail.url
+    , name: detail.name
+    , features: detail.features
+    }
+  );
 
-const decodeOpenWindow = compose(OpenSyncWithMyIFrame, decodeDetail);
-const decodeOpenTab = compose(OpenSyncWithMyIFrame, decodeDetail);
+const decodeOpenWindow = compose(OpenSyncWithMyIFrame, decodeOpenDetail);
+const decodeOpenTab = compose(OpenSyncWithMyIFrame, decodeOpenDetail);
 
 
 const decodeContexMenu = compose(ContextMenu, decodeDetail);

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -95,7 +95,7 @@ export const OpenSyncWithMyIFrame/*:type.OpenSyncWithMyIFrame*/ =
     Driver.element.use(frameElement);
     return {
       type: "Open!WithMyIFrameAndInTheCurrentTick"
-    , isFoced: true
+    , isForced: true
     , options: {uri, name, features, inBackground: false}
     };
   };

--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -301,7 +301,7 @@ const open = (model, options, isForced=false) => {
       ( [ initFX.map(ByID(id))
         , activateFX
         , ( isForced
-          ? Driver.Force
+          ? Driver.force
           : Effects.none
           )
         ]


### PR DESCRIPTION
This fixes both `cmd click` and `window.open`. Fixes https://github.com/mozilla/browser.html/issues/857#issuecomment-176960517.