### PR TITLE
Enter create-tap page once last tab is closed.

### DIFF
--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -363,7 +363,10 @@ const removeByID = (model, id) =>
       , order: remove(model.order, model.order.indexOf(id))
       }
     )
-  , Effects.none
+  , ( model.order.length === 1
+    ? Effects.receive(Create)
+    : Effects.none
+    )
   ];
 
 


### PR DESCRIPTION
I think current behavior of entering screen with no web-view is kind of odd, so this patch just enters `create-web-view` mode if last tab is closed. 

@gordonbrander Feel free to land or tell me that we should do something else here.